### PR TITLE
fix(db): prevent `ActiveRecord::refresh()` parameter mismatch when custom `find()` adds bound parameters.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,3 +34,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(db)!: modernize Oracle support for 19c+ replace `ROWNUM`/CTE pagination with standard `OFFSET x ROWS FETCH NEXT y ROWS ONLY`, fix `buildWithQueries()` emitting unsupported `WITH RECURSIVE` keyword (same issue as MSSQL #34), and update documentation links; minimum supported version is now Oracle 19c.
 - fix(db): keep `inverseOf()` array hydration shape consistent and avoid indirect modification notices in mixed object/array inverse population (`asArray()`).
 - fix(db): MSSQL RBAC cascade gaps and `varbinary` type-casting move binary type-casting to `ColumnSchema::dbTypecast()`, remove `normalizeTableRowData()`, extend `auth_item` triggers to cascade to `auth_assignment`, add `auth_rule` INSTEAD OF triggers, and add `MsSQLManagerTest`/`MsSQLManagerCacheTest`.
+- fix(db): prevent `ActiveRecord::refresh()` parameter mismatch when custom `find()` adds bound parameters.

--- a/src/db/ActiveRecord.php
+++ b/src/db/ActiveRecord.php
@@ -286,7 +286,7 @@ class ActiveRecord extends BaseActiveRecord
         foreach ($this->getPrimaryKey(true) as $key => $value) {
             $pk[$tableName . '.' . $key] = $value;
         }
-        $query->where($pk);
+        $query->andWhere($pk);
 
         /** @var BaseActiveRecord $record */
         $record = $query->noCache()->one();

--- a/tests/base/db/BaseActiveRecord.php
+++ b/tests/base/db/BaseActiveRecord.php
@@ -23,6 +23,7 @@ use yiiunit\data\ar\Cat;
 use yiiunit\data\ar\Category;
 use yiiunit\data\ar\CroppedType;
 use yiiunit\data\ar\Customer;
+use yiiunit\data\ar\CustomerWithInitParams;
 use yiiunit\data\ar\CustomerQuery;
 use yiiunit\data\ar\CustomerWithAlias;
 use yiiunit\data\ar\CustomerWithConstructor;
@@ -2012,6 +2013,30 @@ abstract class BaseActiveRecord extends BaseDatabase
         $model = Customer::findOne(1);
         $this->assertTrue($model->refresh());
         CustomerQuery::$joinWithProfile = false;
+    }
+
+    /**
+     * Ensure no parameter mismatch error occurs if custom ActiveQuery adds a condition with params.
+     *
+     * @see https://github.com/yiisoft/yii2/issues/16396
+     */
+    public function testRefreshWithCustomFindParams(): void
+    {
+        $model = CustomerWithInitParams::findOne(1);
+
+        self::assertNotNull(
+            $model,
+            'Should return an existing active customer for the refresh regression scenario.',
+        );
+        self::assertTrue(
+            $model->refresh(),
+            "Should succeed when the custom ActiveQuery defines bound parameters in 'init()'.",
+        );
+        self::assertSame(
+            1,
+            $model->id,
+            'Should keep the same primary key after reloading the record.',
+        );
     }
 
     public function testFindOneByColumnName(): void

--- a/tests/data/ar/CustomerWithInitParams.php
+++ b/tests/data/ar/CustomerWithInitParams.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+/**
+ * Class CustomerWithInitParams.
+ *
+ * @property int $id
+ * @property int $status
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
+ */
+class CustomerWithInitParams extends ActiveRecord
+{
+    public const STATUS_ACTIVE = 1;
+
+    public static function tableName()
+    {
+        return 'customer';
+    }
+
+    /**
+     * {@inheritdoc}
+     * @return CustomerWithInitParamsQuery
+     */
+    public static function find()
+    {
+        return new CustomerWithInitParamsQuery(static::class);
+    }
+}

--- a/tests/data/ar/CustomerWithInitParamsQuery.php
+++ b/tests/data/ar/CustomerWithInitParamsQuery.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+/**
+ * @link https://www.yiiframework.com/
+ * @copyright Copyright (c) 2008 Yii Software LLC
+ * @license https://www.yiiframework.com/license/
+ */
+
+namespace yiiunit\data\ar;
+
+use yii\db\ActiveQuery;
+
+/**
+ * @extends ActiveQuery<CustomerWithInitParams>
+ *
+ * @author Wilmer Arambula <terabytesoftw@gmail.com>
+ * @since 2.2
+ */
+class CustomerWithInitParamsQuery extends ActiveQuery
+{
+    public function init(): void
+    {
+        parent::init();
+
+        $this->where('[[status]] = :status', [':status' => CustomerWithInitParams::STATUS_ACTIVE]);
+    }
+}


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
