### PR TITLE
refactor(db)!: modernize base `QueryBuilder` remove deprecated `$conditionBuilders` and 8 `build*Condition()` methods; use `::class`, spread operator, short destructuring, `static` closures.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,3 +73,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(rbac)!: extract cascade logic into `CascadeStrategyInterface`, add Oracle driver support, remove MSSQL triggers; fix Oracle BLOB `fetchAll()` corruption via `STRINGIFY_FETCHES`.
 - test(db): add `QueryCacheTest` for MySQL, PostgreSQL, SQLite, and Oracle drivers; align existing MSSQL `QueryCacheTest` to project conventions.
 - test(caching): add `DbCache` tests for SQLite/Oracle, normalize all drivers via `MysqlCacheTest` base class; extract `DbHelper`; fix Oracle BLOB `PdoValue` error in `getDataFieldValue()`.
+- refactor(db)!: modernize base `QueryBuilder` remove deprecated `$conditionBuilders` and 8 `build*Condition()` methods; use `::class`, spread operator, short destructuring, `static` closures.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -435,3 +435,26 @@ DROP TRIGGER IF EXISTS <schema>.trigger_update_auth_item_child;
 DROP TRIGGER IF EXISTS <schema>.trigger_delete_auth_rule;
 DROP TRIGGER IF EXISTS <schema>.trigger_update_auth_rule;
 ```
+
+### Base `QueryBuilder` deprecated API removal
+
+The following deprecated members of `yii\db\QueryBuilder` have been removed (all deprecated since 2.0.14):
+
+- **Property `$conditionBuilders`** — was unused; condition building is handled by `conditionClasses` and
+  `expressionBuilders`.
+- **Methods:**
+  - `buildHashCondition()`
+  - `buildAndCondition()`
+  - `buildNotCondition()`
+  - `buildBetweenCondition()`
+  - `buildInCondition()`
+  - `buildLikeCondition()`
+  - `buildExistsCondition()`
+  - `buildSimpleCondition()`
+
+All of these were replaced by `buildCondition()` in 2.0.14, which delegates to dedicated
+`ConditionBuilder` classes registered in `expressionBuilders`.
+
+**Action required:** If your code calls any of the removed methods directly, replace those calls with
+`$queryBuilder->buildCondition($condition, $params)`. If your code accesses `$conditionBuilders`, remove that reference
+— use `setConditionClasses()` or `setExpressionBuilders()` instead.

--- a/src/db/QueryBuilder.php
+++ b/src/db/QueryBuilder.php
@@ -14,6 +14,15 @@ use yii\db\conditions\ConditionInterface;
 use yii\db\conditions\HashCondition;
 use yii\helpers\StringHelper;
 
+use function count;
+use function get_class;
+use function in_array;
+use function is_array;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_string;
+
 /**
  * QueryBuilder builds a SELECT SQL statement based on the specification given as a [[Query]] object.
  *
@@ -21,7 +30,8 @@ use yii\helpers\StringHelper;
  *
  * QueryBuilder is also used by [[Command]] to build SQL statements such as INSERT, UPDATE, DELETE, CREATE TABLE.
  *
- * For more details and usage information on QueryBuilder, see the [guide article on query builders](guide:db-query-builder).
+ * For more details and usage information on QueryBuilder, see the
+ * [guide article on query builders](guide:db-query-builder).
  *
  * @property-write string[] $conditionClasses Map of condition aliases to condition classes. For example:
  *
@@ -57,12 +67,6 @@ class QueryBuilder extends \yii\base\BaseObject
     public $typeMap = [];
 
     /**
-     * @var array map of query condition to builder methods.
-     * These methods are used by [[buildCondition]] to build SQL conditions from array syntax.
-     * @deprecated since 2.0.14. Is not used, will be dropped in 2.1.0.
-     */
-    protected $conditionBuilders = [];
-    /**
      * @var array map of condition aliases to condition classes. For example:
      *
      * ```
@@ -94,8 +98,8 @@ class QueryBuilder extends \yii\base\BaseObject
      * See default values in [[defaultExpressionBuilders()]] method.
      *
      *
-     * To override existing builders or add custom, use [[setExpressionBuilder()]] method. New items will be added
-     * to the end of this array.
+     * To override existing builders or add custom, use [[setExpressionBuilder()]] method. New items will be added to
+     * the end of this array.
      *
      * To find a builder, [[buildExpression()]] will check the expression class for its exact presence in this map.
      * In case it is NOT present, the array will be iterated in reverse direction, checking whether the expression
@@ -109,13 +113,13 @@ class QueryBuilder extends \yii\base\BaseObject
 
 
     /**
-     * Constructor.
      * @param Connection $connection the database connection.
      * @param array $config name-value pairs that will be used to initialize the object properties
      */
     public function __construct($connection, $config = [])
     {
         $this->db = $connection;
+
         parent::__construct($config);
     }
 
@@ -126,13 +130,19 @@ class QueryBuilder extends \yii\base\BaseObject
     {
         parent::init();
 
-        $this->expressionBuilders = array_merge($this->defaultExpressionBuilders(), $this->expressionBuilders);
-        $this->conditionClasses = array_merge($this->defaultConditionClasses(), $this->conditionClasses);
+        $this->expressionBuilders = [
+            ...$this->defaultExpressionBuilders(),
+            ...$this->expressionBuilders,
+        ];
+        $this->conditionClasses = [
+            ...$this->defaultConditionClasses(),
+            ...$this->conditionClasses,
+        ];
     }
 
     /**
-     * Contains array of default condition classes. Extend this method, if you want to change
-     * default condition classes for the query builder. See [[conditionClasses]] docs for details.
+     * Contains array of default condition classes. Extend this method, if you want to change  default condition classes
+     * for the query builder. See [[conditionClasses]] docs for details.
      *
      * @return array
      * @see conditionClasses
@@ -141,25 +151,25 @@ class QueryBuilder extends \yii\base\BaseObject
     protected function defaultConditionClasses()
     {
         return [
-            'NOT' => 'yii\db\conditions\NotCondition',
-            'AND' => 'yii\db\conditions\AndCondition',
-            'OR' => 'yii\db\conditions\OrCondition',
-            'BETWEEN' => 'yii\db\conditions\BetweenCondition',
-            'NOT BETWEEN' => 'yii\db\conditions\BetweenCondition',
-            'IN' => 'yii\db\conditions\InCondition',
-            'NOT IN' => 'yii\db\conditions\InCondition',
-            'LIKE' => 'yii\db\conditions\LikeCondition',
-            'NOT LIKE' => 'yii\db\conditions\LikeCondition',
-            'OR LIKE' => 'yii\db\conditions\LikeCondition',
-            'OR NOT LIKE' => 'yii\db\conditions\LikeCondition',
-            'EXISTS' => 'yii\db\conditions\ExistsCondition',
-            'NOT EXISTS' => 'yii\db\conditions\ExistsCondition',
+            'NOT' => conditions\NotCondition::class,
+            'AND' => conditions\AndCondition::class,
+            'OR' => conditions\OrCondition::class,
+            'BETWEEN' => conditions\BetweenCondition::class,
+            'NOT BETWEEN' => conditions\BetweenCondition::class,
+            'IN' => conditions\InCondition::class,
+            'NOT IN' => conditions\InCondition::class,
+            'LIKE' => conditions\LikeCondition::class,
+            'NOT LIKE' => conditions\LikeCondition::class,
+            'OR LIKE' => conditions\LikeCondition::class,
+            'OR NOT LIKE' => conditions\LikeCondition::class,
+            'EXISTS' => conditions\ExistsCondition::class,
+            'NOT EXISTS' => conditions\ExistsCondition::class,
         ];
     }
 
     /**
-     * Contains array of default expression builders. Extend this method and override it, if you want to change
-     * default expression builders for this query builder. See [[expressionBuilders]] docs for details.
+     * Contains array of default expression builders. Extend this method and override it, if you want to change default
+     * expression builders for this query builder. See [[expressionBuilders]] docs for details.
      *
      * @return array
      * @see expressionBuilders
@@ -168,34 +178,35 @@ class QueryBuilder extends \yii\base\BaseObject
     protected function defaultExpressionBuilders()
     {
         return [
-            'yii\db\Query' => 'yii\db\QueryExpressionBuilder',
-            'yii\db\PdoValue' => 'yii\db\PdoValueBuilder',
-            'yii\db\Expression' => 'yii\db\ExpressionBuilder',
-            'yii\db\conditions\ConjunctionCondition' => 'yii\db\conditions\ConjunctionConditionBuilder',
-            'yii\db\conditions\NotCondition' => 'yii\db\conditions\NotConditionBuilder',
-            'yii\db\conditions\AndCondition' => 'yii\db\conditions\ConjunctionConditionBuilder',
-            'yii\db\conditions\OrCondition' => 'yii\db\conditions\ConjunctionConditionBuilder',
-            'yii\db\conditions\BetweenCondition' => 'yii\db\conditions\BetweenConditionBuilder',
-            'yii\db\conditions\InCondition' => 'yii\db\conditions\InConditionBuilder',
-            'yii\db\conditions\LikeCondition' => 'yii\db\conditions\LikeConditionBuilder',
-            'yii\db\conditions\ExistsCondition' => 'yii\db\conditions\ExistsConditionBuilder',
-            'yii\db\conditions\SimpleCondition' => 'yii\db\conditions\SimpleConditionBuilder',
-            'yii\db\conditions\HashCondition' => 'yii\db\conditions\HashConditionBuilder',
-            'yii\db\conditions\BetweenColumnsCondition' => 'yii\db\conditions\BetweenColumnsConditionBuilder',
+            Query::class => QueryExpressionBuilder::class,
+            PdoValue::class => PdoValueBuilder::class,
+            Expression::class => ExpressionBuilder::class,
+            conditions\ConjunctionCondition::class => conditions\ConjunctionConditionBuilder::class,
+            conditions\NotCondition::class => conditions\NotConditionBuilder::class,
+            conditions\AndCondition::class => conditions\ConjunctionConditionBuilder::class,
+            conditions\OrCondition::class => conditions\ConjunctionConditionBuilder::class,
+            conditions\BetweenCondition::class => conditions\BetweenConditionBuilder::class,
+            conditions\InCondition::class => conditions\InConditionBuilder::class,
+            conditions\LikeCondition::class => conditions\LikeConditionBuilder::class,
+            conditions\ExistsCondition::class => conditions\ExistsConditionBuilder::class,
+            conditions\SimpleCondition::class => conditions\SimpleConditionBuilder::class,
+            conditions\HashCondition::class => conditions\HashConditionBuilder::class,
+            conditions\BetweenColumnsCondition::class => conditions\BetweenColumnsConditionBuilder::class,
         ];
     }
 
     /**
      * Setter for [[expressionBuilders]] property.
      *
-     * @param string[] $builders array of builders that should be merged with the pre-defined ones
-     * in [[expressionBuilders]] property.
+     * @param string[] $builders array of builders that should be merged with the pre-defined ones in
+     * [[expressionBuilders]] property.
+     *
      * @since 2.0.14
      * @see expressionBuilders
      */
     public function setExpressionBuilders($builders)
     {
-        $this->expressionBuilders = array_merge($this->expressionBuilders, $builders);
+        $this->expressionBuilders = [...$this->expressionBuilders, ...$builders];
     }
 
     /**
@@ -212,24 +223,24 @@ class QueryBuilder extends \yii\base\BaseObject
      */
     public function setConditionClasses($classes)
     {
-        $this->conditionClasses = array_merge($this->conditionClasses, $classes);
+        $this->conditionClasses = [...$this->conditionClasses, ...$classes];
     }
 
     /**
      * Generates a SELECT SQL statement from a [[Query]] object.
      *
      * @param Query $query the [[Query]] object from which the SQL statement will be generated.
-     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will
-     * be included in the result with the additional parameters generated during the query building process.
-     * @return array the generated SQL statement (the first array element) and the corresponding
-     * parameters to be bound to the SQL statement (the second array element). The parameters returned
-     * include those provided in `$params`.
+     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will be included
+     * in the result with the additional parameters generated during the query building process.
+     *
+     * @return array the generated SQL statement (the first array element) and the corresponding parameters to be bound
+     * to the SQL statement (the second array element). The parameters returned include those provided in `$params`.
      */
     public function build($query, $params = [])
     {
         $query = $query->prepare($this);
 
-        $params = empty($params) ? $query->params : array_merge($params, $query->params);
+        $params = empty($params) ? $query->params : [...$params, ...$query->params];
 
         $clauses = [
             $this->buildSelect($query->select, $params, $query->distinct, $query->selectOption),
@@ -250,6 +261,7 @@ class QueryBuilder extends \yii\base\BaseObject
                 }
             }
         }
+
         if (!empty($query->groupBy)) {
             foreach ($query->groupBy as $expression) {
                 if ($expression instanceof ExpressionInterface) {
@@ -259,11 +271,13 @@ class QueryBuilder extends \yii\base\BaseObject
         }
 
         $union = $this->buildUnion($query->union, $params);
+
         if ($union !== '') {
             $sql = "($sql){$this->separator}$union";
         }
 
         $with = $this->buildWithQueries($query->withQueries, $params);
+
         if ($with !== '') {
             $sql = "$with{$this->separator}$sql";
         }
@@ -275,10 +289,13 @@ class QueryBuilder extends \yii\base\BaseObject
      * Builds given $expression
      *
      * @param ExpressionInterface $expression the expression to be built
-     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will
-     * be included in the result with the additional parameters generated during the expression building process.
+     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will be included
+     * in the result with the additional parameters generated during the expression building process.
+     *
      * @return string the SQL statement that will not be neither quoted nor encoded before passing to DBMS
+     *
      * @throws InvalidArgumentException when $expression building is not supported by this QueryBuilder.
+     *
      * @see ExpressionBuilderInterface
      * @see expressionBuilders
      * @since 2.0.14
@@ -296,8 +313,11 @@ class QueryBuilder extends \yii\base\BaseObject
      * Uses [[expressionBuilders]] array to find a suitable builder class.
      *
      * @param ExpressionInterface $expression
+     *
      * @return ExpressionBuilderInterface
+     *
      * @throws InvalidArgumentException when $expression building is not supported by this QueryBuilder.
+     *
      * @since 2.0.14
      * @see expressionBuilders
      */
@@ -314,7 +334,9 @@ class QueryBuilder extends \yii\base\BaseObject
             }
 
             if (!isset($this->expressionBuilders[$className])) {
-                throw new InvalidArgumentException('Expression of class ' . $className . ' can not be built in ' . get_class($this));
+                throw new InvalidArgumentException(
+                    "Expression of class {$className} can not be built in " . get_class($this),
+                );
             }
         }
 
@@ -333,26 +355,33 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Creates an INSERT SQL statement.
+     *
      * For example,
      * ```
-     * $sql = $queryBuilder->insert('user', [
-     *     'name' => 'Sam',
-     *     'age' => 30,
-     * ], $params);
+     * $sql = $queryBuilder->insert(
+     *     'user',
+     *     [
+     *         'name' => 'Sam',
+     *         'age' => 30,
+     *     ],
+     *     $params,
+     * );
      * ```
      * The method will properly escape the table and column names.
      *
      * @param string $table the table that new rows will be inserted into.
-     * @param array|Query $columns the column data (name => value) to be inserted into the table or instance
-     * of [[yii\db\Query|Query]] to perform INSERT INTO ... SELECT SQL statement.
+     * @param array|Query $columns the column data (name => value) to be inserted into the table or instance of
+     * [[yii\db\Query|Query]] to perform INSERT INTO ... SELECT SQL statement.
      * Passing of [[yii\db\Query|Query]] is available since version 2.0.11.
      * @param array $params the binding parameters that will be generated by this method.
      * They should be bound to the DB command later.
+     *
      * @return string the INSERT SQL
      */
     public function insert($table, $columns, &$params)
     {
-        list($names, $placeholders, $values, $params) = $this->prepareInsertValues($table, $columns, $params);
+        [$names, $placeholders, $values, $params] = $this->prepareInsertValues($table, $columns, $params);
+
         return 'INSERT INTO ' . $this->db->quoteTableName($table)
             . (!empty($names) ? ' (' . implode(', ', $names) . ')' : '')
             . (!empty($placeholders) ? ' VALUES (' . implode(', ', $placeholders) . ')' : $values);
@@ -366,19 +395,23 @@ class QueryBuilder extends \yii\base\BaseObject
      * of [[yii\db\Query|Query]] to perform INSERT INTO ... SELECT SQL statement.
      * @param array $params the binding parameters that will be generated by this method.
      * They should be bound to the DB command later.
+     *
      * @return array array of column names, placeholders, values and params.
+     *
      * @since 2.0.14
      */
     protected function prepareInsertValues($table, $columns, $params = [])
     {
         $schema = $this->db->getSchema();
         $tableSchema = $schema->getTableSchema($table);
+
         $columnSchemas = $tableSchema !== null ? $tableSchema->columns : [];
         $names = [];
         $placeholders = [];
         $values = ' DEFAULT VALUES';
+
         if ($columns instanceof Query) {
-            list($names, $values, $params) = $this->prepareInsertSelectSubQuery($columns, $schema, $params);
+            [$names, $values, $params] = $this->prepareInsertSelectSubQuery($columns, $schema, $params);
         } else {
             foreach ($columns as $name => $value) {
                 $names[] = $schema->quoteColumnName($name);
@@ -387,7 +420,7 @@ class QueryBuilder extends \yii\base\BaseObject
                 if ($value instanceof ExpressionInterface) {
                     $placeholders[] = $this->buildExpression($value, $params);
                 } elseif ($value instanceof \yii\db\Query) {
-                    list($sql, $params) = $this->build($value, $params);
+                    [$sql, $params] = $this->build($value, $params);
                     $placeholders[] = "($sql)";
                 } else {
                     $placeholders[] = $this->bindParam($value, $params);
@@ -402,10 +435,13 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param Query $columns Object, which represents select query.
      * @param Schema $schema Schema object to quote column name.
-     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will
-     * be included in the result with the additional parameters generated during the query building process.
+     * @param array $params the parameters to be bound to the generated SQL statement. These parameters will be included
+     * in the result with the additional parameters generated during the query building process.
+     *
      * @return array array of column names, values and params.
+     *
      * @throws InvalidArgumentException if query's select does not contain named parameters only.
+     *
      * @since 2.0.11
      */
     protected function prepareInsertSelectSubQuery($columns, $schema, $params = [])
@@ -414,9 +450,12 @@ class QueryBuilder extends \yii\base\BaseObject
             throw new InvalidArgumentException('Expected select query object with enumerated (named) parameters');
         }
 
-        list($values, $params) = $this->build($columns, $params);
+        [$values, $params] = $this->build($columns, $params);
+
         $names = [];
-        $values = ' ' . $values;
+
+        $values = " {$values}";
+
         foreach ($columns->select as $title => $field) {
             if (is_string($title)) {
                 $names[] = $schema->quoteColumnName($title);
@@ -436,11 +475,15 @@ class QueryBuilder extends \yii\base\BaseObject
      * For example,
      *
      * ```
-     * $sql = $queryBuilder->batchInsert('user', ['name', 'age'], [
-     *     ['Tom', 30],
-     *     ['Jane', 20],
-     *     ['Linda', 25],
-     * ]);
+     * $sql = $queryBuilder->batchInsert(
+     *     'user',
+     *     ['name', 'age'],
+     *     [
+     *         ['Tom', 30],
+     *         ['Jane', 20],
+     *         ['Linda', 25],
+     *     ],
+     * );
      * ```
      *
      * Note that the values in each row must match the corresponding column names.
@@ -451,6 +494,7 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param array $columns the column names
      * @param array|\Generator $rows the rows to be batch inserted into the table
      * @param array $params the binding parameters. This parameter exists since 2.0.14
+     *
      * @return string the batch INSERT SQL statement
      */
     public function batchInsert($table, $columns, $rows, &$params = [])
@@ -460,6 +504,7 @@ class QueryBuilder extends \yii\base\BaseObject
         }
 
         $schema = $this->db->getSchema();
+
         if (($tableSchema = $schema->getTableSchema($table)) !== null) {
             $columnSchemas = $tableSchema->columns;
         } else {
@@ -467,12 +512,14 @@ class QueryBuilder extends \yii\base\BaseObject
         }
 
         $values = [];
+
         foreach ($rows as $row) {
             $vs = [];
             foreach ($row as $i => $value) {
                 if (isset($columns[$i], $columnSchemas[$columns[$i]])) {
                     $value = $columnSchemas[$columns[$i]]->dbTypecast($value);
                 }
+
                 if (is_string($value)) {
                     $value = $schema->quoteValue($value);
                 } elseif (is_float($value)) {
@@ -485,10 +532,13 @@ class QueryBuilder extends \yii\base\BaseObject
                 } elseif ($value instanceof ExpressionInterface) {
                     $value = $this->buildExpression($value, $params);
                 }
+
                 $vs[] = $value;
             }
+
             $values[] = '(' . implode(', ', $vs) . ')';
         }
+
         if (empty($values)) {
             return '';
         }
@@ -502,20 +552,22 @@ class QueryBuilder extends \yii\base\BaseObject
     }
 
     /**
-     * Creates an SQL statement to insert rows into a database table if
-     * they do not already exist (matching unique constraints),
-     * or update them if they do.
+     * Creates an SQL statement to insert rows into a database table if they do not already exist (matching unique
+     * constraints), or update them if they do.
      *
      * For example,
      *
      * ```
-     * $sql = $queryBuilder->upsert('pages', [
-     *     'name' => 'Front page',
-     *     'url' => 'https://example.com/', // url is unique
-     *     'visits' => 0,
-     * ], [
-     *     'visits' => new \yii\db\Expression('visits + 1'),
-     * ], $params);
+     * $sql = $queryBuilder->upsert(
+     *     'pages',
+     *     [
+     *         'name' => 'Front page',
+     *         'url' => 'https://example.com/', // url is unique
+     *         'visits' => 0,
+     *     ],
+     *     ['visits' => new \yii\db\Expression('visits + 1')],
+     *     $params,
+     * );
      * ```
      *
      * The method will properly escape the table and column names.
@@ -528,8 +580,11 @@ class QueryBuilder extends \yii\base\BaseObject
      * If `false` is passed, no update will be performed if the column data already exists.
      * @param array $params the binding parameters that will be generated by this method.
      * They should be bound to the DB command later.
+     *
      * @return string the resulting SQL.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
      * @since 2.0.14
      */
     public function upsert($table, $insertColumns, $updateColumns, &$params)
@@ -543,18 +598,23 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param array|bool $updateColumns
      * @param Constraint[] $constraints this parameter recieves a matched constraint list.
      * The constraints will be unique by their column names.
+     *
      * @return array
+     *
      * @since 2.0.14
      */
     protected function prepareUpsertColumns($table, $insertColumns, $updateColumns, &$constraints = [])
     {
         if ($insertColumns instanceof Query) {
-            list($insertNames) = $this->prepareInsertSelectSubQuery($insertColumns, $this->db->getSchema());
+            [$insertNames] = $this->prepareInsertSelectSubQuery($insertColumns, $this->db->getSchema());
         } else {
             $insertNames = array_map([$this->db, 'quoteColumnName'], array_keys($insertColumns));
         }
+
         $uniqueNames = $this->getTableUniqueColumnNames($table, $insertNames, $constraints);
+
         $uniqueNames = array_map([$this->db, 'quoteColumnName'], $uniqueNames);
+
         if ($updateColumns !== true) {
             return [$uniqueNames, $insertNames, null];
         }
@@ -571,42 +631,66 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string[] $columns source column list.
      * @param Constraint[] $constraints this parameter optionally recieves a matched constraint list.
      * The constraints will be unique by their column names.
+     *
      * @return string[] column list.
      */
     private function getTableUniqueColumnNames($name, $columns, &$constraints = [])
     {
         $schema = $this->db->getSchema();
+
         if (!$schema instanceof ConstraintFinderInterface) {
             return [];
         }
 
         $constraints = [];
+
         $primaryKey = $schema->getTablePrimaryKey($name);
+
         if ($primaryKey !== null) {
             $constraints[] = $primaryKey;
         }
+
         foreach ($schema->getTableIndexes($name) as $constraint) {
             if ($constraint->isUnique) {
                 $constraints[] = $constraint;
             }
         }
-        $constraints = array_merge($constraints, $schema->getTableUniques($name));
+
+        $constraints = [...$constraints, ...$schema->getTableUniques($name)];
+
         // Remove duplicates
-        $constraints = array_combine(array_map(function (Constraint $constraint) {
-            $columns = $constraint->columnNames;
-            sort($columns, SORT_STRING);
-            return json_encode($columns);
-        }, $constraints), $constraints);
+        $constraints = array_combine(
+            array_map(
+                static function (Constraint $constraint): bool|string {
+                    $columns = $constraint->columnNames;
+                    sort($columns, SORT_STRING);
+
+                    return json_encode($columns);
+                },
+                $constraints,
+            ),
+            $constraints,
+        );
+
         $columnNames = [];
+
         // Remove all constraints which do not cover the specified column list
-        $constraints = array_values(array_filter($constraints, function (Constraint $constraint) use ($schema, $columns, &$columnNames) {
-            $constraintColumnNames = array_map([$schema, 'quoteColumnName'], $constraint->columnNames);
-            $result = !array_diff($constraintColumnNames, $columns);
-            if ($result) {
-                $columnNames = array_merge($columnNames, $constraintColumnNames);
-            }
-            return $result;
-        }));
+        $constraints = array_values(
+            array_filter(
+                $constraints,
+                static function (Constraint $constraint) use ($schema, $columns, &$columnNames): bool {
+                    $constraintColumnNames = array_map([$schema, 'quoteColumnName'], $constraint->columnNames);
+                    $result = !array_diff($constraintColumnNames, $columns);
+
+                    if ($result) {
+                        $columnNames = array_merge($columnNames, $constraintColumnNames);
+                    }
+
+                    return $result;
+                }
+            ),
+        );
+
         return array_unique($columnNames);
     }
 
@@ -617,7 +701,12 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * ```
      * $params = [];
-     * $sql = $queryBuilder->update('user', ['status' => 1], 'age > 30', $params);
+     * $sql = $queryBuilder->update(
+     *     'user',
+     *     ['status' => 1],
+     *     'age > 30',
+     *     $params,
+     * );
      * ```
      *
      * The method will properly escape the table and column names.
@@ -626,34 +715,44 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param array $columns the column data (name => value) to be updated.
      * @param array|string $condition the condition that will be put in the WHERE part. Please
      * refer to [[Query::where()]] on how to specify condition.
-     * @param array $params the binding parameters that will be modified by this method
-     * so that they can be bound to the DB command later.
+     * @param array $params the binding parameters that will be modified by this method so that they can be bound to the
+     * DB command later.
+     *
      * @return string the UPDATE SQL
      */
     public function update($table, $columns, $condition, &$params)
     {
-        list($lines, $params) = $this->prepareUpdateSets($table, $columns, $params);
+        [$lines, $params] = $this->prepareUpdateSets($table, $columns, $params);
+
         $sql = 'UPDATE ' . $this->db->quoteTableName($table) . ' SET ' . implode(', ', $lines);
         $where = $this->buildWhere($condition, $params);
+
         return $where === '' ? $sql : $sql . ' ' . $where;
     }
 
     /**
      * Prepares a `SET` parts for an `UPDATE` SQL statement.
+     *
      * @param string $table the table to be updated.
      * @param array $columns the column data (name => value) to be updated.
-     * @param array $params the binding parameters that will be modified by this method
-     * so that they can be bound to the DB command later.
-     * @return array an array `SET` parts for an `UPDATE` SQL statement (the first array element) and params (the second array element).
+     * @param array $params the binding parameters that will be modified by this method so that they can be bound to the
+     * DB command later.
+     *
+     * @return array an array `SET` parts for an `UPDATE` SQL statement (the first array element) and params (the second
+     * array element).
+     *
      * @since 2.0.14
      */
     protected function prepareUpdateSets($table, $columns, $params = [])
     {
         $tableSchema = $this->db->getTableSchema($table);
         $columnSchemas = $tableSchema !== null ? $tableSchema->columns : [];
+
         $sets = [];
+
         foreach ($columns as $name => $value) {
             $value = isset($columnSchemas[$name]) ? $columnSchemas[$name]->dbTypecast($value) : $value;
+
             if ($value instanceof ExpressionInterface) {
                 $placeholder = $this->buildExpression($value, $params);
             } else {
@@ -662,6 +761,7 @@ class QueryBuilder extends \yii\base\BaseObject
 
             $sets[] = $this->db->quoteColumnName($name) . '=' . $placeholder;
         }
+
         return [$sets, $params];
     }
 
@@ -671,16 +771,20 @@ class QueryBuilder extends \yii\base\BaseObject
      * For example,
      *
      * ```
-     * $sql = $queryBuilder->delete('user', 'status = 0');
+     * $sql = $queryBuilder->delete(
+     *     'user',
+     *     'status = 0',
+     * );
      * ```
      *
      * The method will properly escape the table and column names.
      *
      * @param string $table the table where the data will be deleted from.
-     * @param array|string $condition the condition that will be put in the WHERE part. Please
-     * refer to [[Query::where()]] on how to specify condition.
-     * @param array $params the binding parameters that will be modified by this method
-     * so that they can be bound to the DB command later.
+     * @param array|string $condition the condition that will be put in the WHERE part.
+     * Please refer to [[Query::where()]] on how to specify condition.
+     * @param array $params the binding parameters that will be modified by this method so that they can be bound to the
+     * DB command later.
+     *
      * @return string the DELETE SQL
      */
     public function delete($table, $condition, &$params)
@@ -694,33 +798,38 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * Builds a SQL statement for creating a new DB table.
      *
-     * The columns in the new table should be specified as name-definition pairs (e.g. 'name' => 'string'),
-     * where name stands for a column name which will be properly quoted by the method, and definition
-     * stands for the column type which must contain an abstract DB type.
+     * The columns in the new table should be specified as name-definition pairs (e.g. 'name' => 'string'), where name
+     * stands for a column name which will be properly quoted by the method, and definition stands for the column type
+     * which must contain an abstract DB type.
      * The [[getColumnType()]] method will be invoked to convert any abstract type into a physical one.
      *
-     * If a column is specified with definition only (e.g. 'PRIMARY KEY (name, type)'), it will be directly
+     * If a column is specified with definition only (for example. 'PRIMARY KEY (name, type)'), it will be directly
      * inserted into the generated SQL.
      *
      * For example,
      *
      * ```
-     * $sql = $queryBuilder->createTable('user', [
-     *  'id' => 'pk',
-     *  'name' => 'string',
-     *  'age' => 'integer',
-     *  'column_name double precision null default null', # definition only example
-     * ]);
+     * $sql = $queryBuilder->createTable(
+     *     'user',
+     *     [
+     *         'id' => 'pk',
+     *         'name' => 'string',
+     *         'age' => 'integer',
+     *         'column_name double precision null default null', # definition only example
+     *     ],
+     * );
      * ```
      *
      * @param string $table the name of the table to be created. The name will be properly quoted by the method.
      * @param array $columns the columns (name => definition) in the new table.
      * @param string|null $options additional SQL fragment that will be appended to the generated SQL.
+     *
      * @return string the SQL statement for creating a new DB table.
      */
     public function createTable($table, $columns, $options = null)
     {
         $cols = [];
+
         foreach ($columns as $name => $type) {
             if (is_string($name)) {
                 $cols[] = "\t" . $this->db->quoteColumnName($name) . ' ' . $this->getColumnType($type);
@@ -728,6 +837,7 @@ class QueryBuilder extends \yii\base\BaseObject
                 $cols[] = "\t" . $type;
             }
         }
+
         $sql = 'CREATE TABLE ' . $this->db->quoteTableName($table) . " (\n" . implode(",\n", $cols) . "\n)";
 
         return $options === null ? $sql : $sql . ' ' . $options;
@@ -735,18 +845,25 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for renaming a DB table.
+     *
      * @param string $oldName the table to be renamed. The name will be properly quoted by the method.
      * @param string $newName the new table name. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for renaming a DB table.
      */
     public function renameTable($oldName, $newName)
     {
-        return 'RENAME TABLE ' . $this->db->quoteTableName($oldName) . ' TO ' . $this->db->quoteTableName($newName);
+        return 'RENAME TABLE '
+            . $this->db->quoteTableName($oldName)
+            . ' TO '
+            . $this->db->quoteTableName($newName);
     }
 
     /**
      * Builds a SQL statement for dropping a DB table.
+     *
      * @param string $table the table to be dropped. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping a DB table.
      */
     public function dropTable($table)
@@ -756,9 +873,11 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for adding a primary key constraint to an existing table.
+     *
      * @param string $name the name of the primary key constraint.
      * @param string $table the table that the primary key constraint will be added to.
      * @param string|array $columns comma separated string or array of columns that the primary key will consist of.
+     *
      * @return string the SQL statement for adding a primary key constraint to an existing table.
      */
     public function addPrimaryKey($name, $table, $columns)
@@ -771,26 +890,35 @@ class QueryBuilder extends \yii\base\BaseObject
             $columns[$i] = $this->db->quoteColumnName($col);
         }
 
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ADD CONSTRAINT '
-            . $this->db->quoteColumnName($name) . ' PRIMARY KEY ('
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' ADD CONSTRAINT '
+            . $this->db->quoteColumnName($name)
+            . ' PRIMARY KEY ('
             . implode(', ', $columns) . ')';
     }
 
     /**
      * Builds a SQL statement for removing a primary key constraint to an existing table.
+     *
      * @param string $name the name of the primary key constraint to be removed.
      * @param string $table the table that the primary key constraint will be removed from.
+     *
      * @return string the SQL statement for removing a primary key constraint from an existing table.
      */
     public function dropPrimaryKey($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' DROP CONSTRAINT '
+            . $this->db->quoteColumnName($name);
     }
 
     /**
      * Builds a SQL statement for truncating a DB table.
+     *
      * @param string $table the table to be truncated. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for truncating a DB table.
      */
     public function truncateTable($table)
@@ -800,67 +928,92 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for adding a new DB column.
-     * @param string $table the table that the new column will be added to. The table name will be properly quoted by the method.
+     *
+     * @param string $table the table that the new column will be added to. The table name will be properly quoted by
+     * the method.
      * @param string $column the name of the new column. The name will be properly quoted by the method.
-     * @param string $type the column type. The [[getColumnType()]] method will be invoked to convert abstract column type (if any)
-     * into the physical one. Anything that is not recognized as abstract type will be kept in the generated SQL.
-     * For example, 'string' will be turned into 'varchar(255)', while 'string not null' will become 'varchar(255) not null'.
+     * @param string $type the column type. The [[getColumnType()]] method will be invoked to convert abstract column
+     * type (if any) into the physical one. Anything that is not recognized as abstract type will be kept in the
+     * generated SQL.
+     * For example, 'string' will be turned into 'varchar(255)', while 'string not null' will become
+     * 'varchar(255) not null'.
+     *
      * @return string the SQL statement for adding a new column.
      */
     public function addColumn($table, $column, $type)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' ADD ' . $this->db->quoteColumnName($column) . ' '
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' ADD '
+            . $this->db->quoteColumnName($column)
+            . ' '
             . $this->getColumnType($type);
     }
 
     /**
      * Builds a SQL statement for dropping a DB column.
+     *
      * @param string $table the table whose column is to be dropped. The name will be properly quoted by the method.
      * @param string $column the name of the column to be dropped. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping a DB column.
      */
     public function dropColumn($table, $column)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP COLUMN ' . $this->db->quoteColumnName($column);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' DROP COLUMN '
+            . $this->db->quoteColumnName($column);
     }
 
     /**
      * Builds a SQL statement for renaming a column.
+     *
      * @param string $table the table whose column is to be renamed. The name will be properly quoted by the method.
      * @param string $oldName the old name of the column. The name will be properly quoted by the method.
      * @param string $newName the new name of the column. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for renaming a DB column.
      */
     public function renameColumn($table, $oldName, $newName)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' RENAME COLUMN ' . $this->db->quoteColumnName($oldName)
-            . ' TO ' . $this->db->quoteColumnName($newName);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' RENAME COLUMN '
+            . $this->db->quoteColumnName($oldName)
+            . ' TO '
+            . $this->db->quoteColumnName($newName);
     }
 
     /**
      * Builds a SQL statement for changing the definition of a column.
-     * @param string $table the table whose column is to be changed. The table name will be properly quoted by the method.
+     *
+     * @param string $table the table whose column is to be changed. The table name will be properly quoted by the
+     * method.
      * @param string $column the name of the column to be changed. The name will be properly quoted by the method.
      * @param string $type the new column type. The [[getColumnType()]] method will be invoked to convert abstract
-     * column type (if any) into the physical one. Anything that is not recognized as abstract type will be kept
-     * in the generated SQL. For example, 'string' will be turned into 'varchar(255)', while 'string not null'
-     * will become 'varchar(255) not null'.
+     * column type (if any) into the physical one. Anything that is not recognized as abstract type will be kept in the
+     * generated SQL. For example, 'string' will be turned into 'varchar(255)', while 'string not null' will become
+     * 'varchar(255) not null'.
+     *
      * @return string the SQL statement for changing the definition of a column.
      */
     public function alterColumn($table, $column, $type)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' CHANGE '
-            . $this->db->quoteColumnName($column) . ' '
-            . $this->db->quoteColumnName($column) . ' '
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' CHANGE '
+            . $this->db->quoteColumnName($column)
+            . ' '
+            . $this->db->quoteColumnName($column)
+            . ' '
             . $this->getColumnType($type);
     }
 
     /**
      * Builds a SQL statement for adding a foreign key constraint to an existing table.
      * The method will properly quote the table and column names.
+     *
      * @param string $name the name of the foreign key constraint.
      * @param string $table the table that the foreign key constraint will be added to.
      * @param string|array $columns the name of the column to that the constraint will be added on.
@@ -868,8 +1021,11 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string $refTable the table that the foreign key references to.
      * @param string|array $refColumns the name of the column that the foreign key references to.
      * If there are multiple columns, separate them with commas or use an array to represent them.
-     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
-     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION, SET DEFAULT, SET NULL
+     * @param string|null $delete the ON DELETE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION,
+     * SET DEFAULT, SET NULL
+     * @param string|null $update the ON UPDATE option. Most DBMS support these options: RESTRICT, CASCADE, NO ACTION,
+     * SET DEFAULT, SET NULL
+     *
      * @return string the SQL statement for adding a foreign key constraint to an existing table.
      */
     public function addForeignKey($name, $table, $columns, $refTable, $refColumns, $delete = null, $update = null)
@@ -879,6 +1035,7 @@ class QueryBuilder extends \yii\base\BaseObject
             . ' FOREIGN KEY (' . $this->buildColumns($columns) . ')'
             . ' REFERENCES ' . $this->db->quoteTableName($refTable)
             . ' (' . $this->buildColumns($refColumns) . ')';
+
         if ($delete !== null) {
             $sql .= ' ON DELETE ' . $delete;
         }
@@ -891,24 +1048,32 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for dropping a foreign key constraint.
-     * @param string $name the name of the foreign key constraint to be dropped. The name will be properly quoted by the method.
+     *
+     * @param string $name the name of the foreign key constraint to be dropped. The name will be properly quoted by the
+     * method.
      * @param string $table the table whose foreign is to be dropped. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping a foreign key constraint.
      */
     public function dropForeignKey($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' DROP CONSTRAINT '
+            . $this->db->quoteColumnName($name);
     }
 
     /**
      * Builds a SQL statement for creating a new index.
+     *
      * @param string $name the name of the index. The name will be properly quoted by the method.
-     * @param string $table the table that the new index will be created for. The table name will be properly quoted by the method.
+     * @param string $table the table that the new index will be created for. The table name will be properly quoted by
+     * the method.
      * @param string|array $columns the column(s) that should be included in the index. If there are multiple columns,
-     * separate them with commas or use an array to represent them. Each column name will be properly quoted
-     * by the method, unless a parenthesis is found in the name.
+     * separate them with commas or use an array to represent them. Each column name will be properly quoted by the
+     * method, unless a parenthesis is found in the name.
      * @param bool $unique whether to add UNIQUE constraint on the created index.
+     *
      * @return string the SQL statement for creating a new index.
      */
     public function createIndex($name, $table, $columns, $unique = false)
@@ -921,17 +1086,23 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for dropping an index.
+     *
      * @param string $name the name of the index to be dropped. The name will be properly quoted by the method.
      * @param string $table the table whose index is to be dropped. The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping an index.
      */
     public function dropIndex($name, $table)
     {
-        return 'DROP INDEX ' . $this->db->quoteTableName($name) . ' ON ' . $this->db->quoteTableName($table);
+        return 'DROP INDEX '
+            . $this->db->quoteTableName($name)
+            . ' ON '
+            . $this->db->quoteTableName($table);
     }
 
     /**
      * Creates a SQL command for adding an unique constraint to an existing table.
+     *
      * @param string $name the name of the unique constraint.
      * The name will be properly quoted by the method.
      * @param string $table the table that the unique constraint will be added to.
@@ -939,7 +1110,9 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string|array $columns the name of the column to that the constraint will be added on.
      * If there are multiple columns, separate them with commas.
      * The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for adding an unique constraint to an existing table.
+     *
      * @since 2.0.13
      */
     public function addUnique($name, $table, $columns)
@@ -947,6 +1120,7 @@ class QueryBuilder extends \yii\base\BaseObject
         if (is_string($columns)) {
             $columns = preg_split('/\s*,\s*/', $columns, -1, PREG_SPLIT_NO_EMPTY);
         }
+
         foreach ($columns as $i => $col) {
             $columns[$i] = $this->db->quoteColumnName($col);
         }
@@ -958,52 +1132,69 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Creates a SQL command for dropping an unique constraint.
+     *
      * @param string $name the name of the unique constraint to be dropped.
      * The name will be properly quoted by the method.
      * @param string $table the table whose unique constraint is to be dropped.
      * The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping an unique constraint.
+     *
      * @since 2.0.13
      */
     public function dropUnique($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' DROP CONSTRAINT '
+            . $this->db->quoteColumnName($name);
     }
 
     /**
      * Creates a SQL command for adding a check constraint to an existing table.
+     *
      * @param string $name the name of the check constraint.
      * The name will be properly quoted by the method.
      * @param string $table the table that the check constraint will be added to.
      * The name will be properly quoted by the method.
      * @param string $expression the SQL of the `CHECK` constraint.
+     *
      * @return string the SQL statement for adding a check constraint to an existing table.
+     *
      * @since 2.0.13
      */
     public function addCheck($name, $table, $expression)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table) . ' ADD CONSTRAINT '
-            . $this->db->quoteColumnName($name) . ' CHECK (' . $this->db->quoteSql($expression) . ')';
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' ADD CONSTRAINT '
+            . $this->db->quoteColumnName($name)
+            . ' CHECK (' . $this->db->quoteSql($expression) . ')';
     }
 
     /**
      * Creates a SQL command for dropping a check constraint.
+     *
      * @param string $name the name of the check constraint to be dropped.
      * The name will be properly quoted by the method.
      * @param string $table the table whose check constraint is to be dropped.
      * The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping a check constraint.
+     *
      * @since 2.0.13
      */
     public function dropCheck($name, $table)
     {
-        return 'ALTER TABLE ' . $this->db->quoteTableName($table)
-            . ' DROP CONSTRAINT ' . $this->db->quoteColumnName($name);
+        return 'ALTER TABLE '
+            . $this->db->quoteTableName($table)
+            . ' DROP CONSTRAINT '
+            . $this->db->quoteColumnName($name);
     }
 
     /**
      * Creates a SQL command for adding a default value constraint to an existing table.
+     *
      * @param string $name the name of the default value constraint.
      * The name will be properly quoted by the method.
      * @param string $table the table that the default value constraint will be added to.
@@ -1011,38 +1202,52 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string $column the name of the column to that the constraint will be added on.
      * The name will be properly quoted by the method.
      * @param mixed $value default value.
+     *
      * @return string the SQL statement for adding a default value constraint to an existing table.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
      * @since 2.0.13
      */
     public function addDefaultValue($name, $table, $column, $value)
     {
-        throw new NotSupportedException($this->db->getDriverName() . ' does not support adding default value constraints.');
+        throw new NotSupportedException(
+            $this->db->getDriverName() . ' does not support adding default value constraints.',
+        );
     }
 
     /**
      * Creates a SQL command for dropping a default value constraint.
+     *
      * @param string $name the name of the default value constraint to be dropped.
      * The name will be properly quoted by the method.
      * @param string $table the table whose default value constraint is to be dropped.
      * The name will be properly quoted by the method.
+     *
      * @return string the SQL statement for dropping a default value constraint.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS.
+     *
      * @since 2.0.13
      */
     public function dropDefaultValue($name, $table)
     {
-        throw new NotSupportedException($this->db->getDriverName() . ' does not support dropping default value constraints.');
+        throw new NotSupportedException(
+            $this->db->getDriverName() . ' does not support dropping default value constraints.',
+        );
     }
 
     /**
      * Creates a SQL statement for resetting the sequence value of a table's primary key.
-     * The sequence will be reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
+     * The sequence will be reset such that the primary key of the next new row inserted will have the specified value
+     * or the maximum existing value +1.
+     *
      * @param string $tableName the name of the table whose primary key sequence will be reset
      * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
      * the next new row's primary key will have the maximum existing value +1.
+     *
      * @return string the SQL statement for resetting sequence
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS
      */
     public function resetSequence($tableName, $value = null)
@@ -1053,12 +1258,15 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * Execute a SQL statement for resetting the sequence value of a table's primary key.
      * Reason for execute is that some databases (Oracle) need several queries to do so.
-     * The sequence is reset such that the primary key of the next new row inserted
-     * will have the specified value or the maximum existing value +1.
+     * The sequence is reset such that the primary key of the next new row inserted will have the specified value or the
+     * maximum existing `value +1`.
+     *
      * @param string $table the name of the table whose primary key sequence is reset
      * @param array|string|null $value the value for the primary key of the next new row inserted. If this is not set,
-     * the next new row's primary key will have the maximum existing value +1.
+     * the next new row's primary key will have the maximum existing `value +1`.
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS
+     *
      * @since 2.0.16
      */
     public function executeResetSequence($table, $value = null)
@@ -1068,37 +1276,54 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds a SQL statement for enabling or disabling integrity check.
+     *
      * @param bool $check whether to turn on or off the integrity check.
      * @param string $schema the schema of the tables. Defaults to empty string, meaning the current or default schema.
      * @param string $table the table name. Defaults to empty string, meaning that no table will be changed.
+     *
      * @return string the SQL statement for checking integrity
+     *
      * @throws NotSupportedException if this is not supported by the underlying DBMS
      */
     public function checkIntegrity($check = true, $schema = '', $table = '')
     {
-        throw new NotSupportedException($this->db->getDriverName() . ' does not support enabling/disabling integrity check.');
+        throw new NotSupportedException(
+            $this->db->getDriverName() . ' does not support enabling/disabling integrity check.',
+        );
     }
 
     /**
      * Builds a SQL command for adding comment to column.
      *
-     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
-     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the
+     * method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the
+     * method.
      * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     *
      * @return string the SQL statement for adding comment on column
+     *
      * @since 2.0.8
      */
     public function addCommentOnColumn($table, $column, $comment)
     {
-        return 'COMMENT ON COLUMN ' . $this->db->quoteTableName($table) . '.' . $this->db->quoteColumnName($column) . ' IS ' . $this->db->quoteValue($comment);
+        return 'COMMENT ON COLUMN '
+            . $this->db->quoteTableName($table)
+            . '.'
+            . $this->db->quoteColumnName($column)
+            . ' IS '
+            . $this->db->quoteValue($comment);
     }
 
     /**
      * Builds a SQL command for adding comment to table.
      *
-     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the
+     * method.
      * @param string $comment the text of the comment to be added. The comment will be properly quoted by the method.
+     *
      * @return string the SQL statement for adding comment on table
+     *
      * @since 2.0.8
      */
     public function addCommentOnTable($table, $comment)
@@ -1109,21 +1334,32 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * Builds a SQL command for adding comment to column.
      *
-     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
-     * @param string $column the name of the column to be commented. The column name will be properly quoted by the method.
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the
+     * method.
+     * @param string $column the name of the column to be commented. The column name will be properly quoted by the
+     * method.
+     *
      * @return string the SQL statement for adding comment on column
+     *
      * @since 2.0.8
      */
     public function dropCommentFromColumn($table, $column)
     {
-        return 'COMMENT ON COLUMN ' . $this->db->quoteTableName($table) . '.' . $this->db->quoteColumnName($column) . ' IS NULL';
+        return 'COMMENT ON COLUMN '
+            . $this->db->quoteTableName($table)
+            . '.'
+            . $this->db->quoteColumnName($column)
+            . ' IS NULL';
     }
 
     /**
      * Builds a SQL command for adding comment to table.
      *
-     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the method.
+     * @param string $table the table whose column is to be commented. The table name will be properly quoted by the
+     * method.
+     *
      * @return string the SQL statement for adding comment on column
+     *
      * @since 2.0.8
      */
     public function dropCommentFromTable($table)
@@ -1137,16 +1373,18 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param string $viewName the name of the view to be created.
      * @param string|Query $subQuery the select statement which defines the view.
      * This can be either a string or a [[Query]] object.
+     *
      * @return string the `CREATE VIEW` SQL statement.
+     *
      * @since 2.0.14
      */
     public function createView($viewName, $subQuery)
     {
         if ($subQuery instanceof Query) {
-            list($rawQuery, $params) = $this->build($subQuery);
+            [$rawQuery, $params] = $this->build($subQuery);
             array_walk(
                 $params,
-                function (&$param) {
+                function (&$param): void {
                     $param = $this->db->quoteValue($param);
                 }
             );
@@ -1160,7 +1398,9 @@ class QueryBuilder extends \yii\base\BaseObject
      * Drops a SQL View.
      *
      * @param string $viewName the name of the view to be dropped.
+     *
      * @return string the `DROP VIEW` SQL statement.
+     *
      * @since 2.0.14
      */
     public function dropView($viewName)
@@ -1194,18 +1434,19 @@ class QueryBuilder extends \yii\base\BaseObject
      * - `money`: money type, will be converted into "decimal(19,4)"
      * - `binary`: binary data type, will be converted into "blob"
      *
-     * If the abstract type contains two or more parts separated by spaces (e.g. "string NOT NULL"), then only
-     * the first part will be converted, and the rest of the parts will be appended to the converted result.
+     * If the abstract type contains two or more parts separated by spaces (e.g. "string NOT NULL"), then only the first
+     * part will be converted, and the rest of the parts will be appended to the converted result.
      * For example, 'string NOT NULL' is converted to 'varchar(255) NOT NULL'.
      *
-     * For some of the abstract types you can also specify a length or precision constraint
-     * by appending it in round brackets directly to the type.
+     * For some of the abstract types you can also specify a length or precision constraint by appending it in round
+     * brackets directly to the type.
      * For example `string(32)` will be converted into "varchar(32)" on a MySQL database.
-     * If the underlying DBMS does not support these kind of constraints for a type it will
-     * be ignored.
+     * If the underlying DBMS does not support these kind of constraints for a type it will be ignored.
      *
      * If a type cannot be found in [[typeMap]], it will be returned without any change.
+     *
      * @param string|ColumnSchemaBuilder $type abstract column type
+     *
      * @return string physical column type.
      */
     public function getColumnType($type)
@@ -1218,7 +1459,7 @@ class QueryBuilder extends \yii\base\BaseObject
             return $this->typeMap[$type];
         } elseif (preg_match('/^(\w+)\((.+?)\)(.*)$/', $type, $matches)) {
             if (isset($this->typeMap[$matches[1]])) {
-                return preg_replace('/\(.+\)/', '(' . $matches[2] . ')', $this->typeMap[$matches[1]]) . $matches[3];
+                return preg_replace('/\(.+\)/', "($matches[2])", $this->typeMap[$matches[1]]) . $matches[3];
             }
         } elseif (preg_match('/^(\w+)\s+/', $type, $matches)) {
             if (isset($this->typeMap[$matches[1]])) {
@@ -1234,11 +1475,13 @@ class QueryBuilder extends \yii\base\BaseObject
      * @param array $params the binding parameters to be populated
      * @param bool $distinct
      * @param string|null $selectOption
+     *
      * @return string the SELECT clause built from [[Query::$select]].
      */
     public function buildSelect($columns, &$params, $distinct = false, $selectOption = null)
     {
         $select = $distinct ? 'SELECT DISTINCT' : 'SELECT';
+
         if ($selectOption !== null) {
             $select .= ' ' . $selectOption;
         }
@@ -1255,7 +1498,7 @@ class QueryBuilder extends \yii\base\BaseObject
                     $columns[$i] = $this->buildExpression($column, $params) . ' AS ' . $this->db->quoteColumnName($i);
                 }
             } elseif ($column instanceof Query) {
-                list($sql, $params) = $this->build($column, $params);
+                [$sql, $params] = $this->build($column, $params);
                 $columns[$i] = "($sql) AS " . $this->db->quoteColumnName($i);
             } elseif (is_string($i) && $i !== $column) {
                 if (strpos($column, '(') === false) {
@@ -1264,7 +1507,9 @@ class QueryBuilder extends \yii\base\BaseObject
                 $columns[$i] = "$column AS " . $this->db->quoteColumnName($i);
             } elseif (strpos($column, '(') === false) {
                 if (preg_match('/^(.*?)(?i:\s+as\s+|\s+)([\w\-_\.]+)$/', $column, $matches)) {
-                    $columns[$i] = $this->db->quoteColumnName($matches[1]) . ' AS ' . $this->db->quoteColumnName($matches[2]);
+                    $columns[$i] = $this->db->quoteColumnName($matches[1])
+                        . ' AS '
+                        . $this->db->quoteColumnName($matches[2]);
                 } else {
                     $columns[$i] = $this->db->quoteColumnName($column);
                 }
@@ -1277,6 +1522,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param array $tables
      * @param array $params the binding parameters to be populated
+     *
      * @return string the FROM clause built from [[Query::$from]].
      */
     public function buildFrom($tables, &$params)
@@ -1293,7 +1539,9 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param array $joins
      * @param array $params the binding parameters to be populated
+     *
      * @return string the JOIN clause built from [[Query::$join]].
+     *
      * @throws Exception if the $joins parameter is not in proper format
      */
     public function buildJoin($joins, &$params)
@@ -1304,13 +1552,20 @@ class QueryBuilder extends \yii\base\BaseObject
 
         foreach ($joins as $i => $join) {
             if (!is_array($join) || !isset($join[0], $join[1])) {
-                throw new Exception('A join clause must be specified as an array of join type, join table, and optionally join condition.');
+                throw new Exception(
+                    'A join clause must be specified as an array of join type, join table, and optionally join condition.',
+                );
             }
+
             // 0:join type, 1:join table, 2:on-condition (optional)
-            list($joinType, $table) = $join;
+            [$joinType, $table] = $join;
+
             $tables = $this->quoteTableNames((array)$table, $params);
+
             $table = reset($tables);
+
             $joins[$i] = "$joinType $table";
+
             if (isset($join[2])) {
                 $condition = $this->buildCondition($join[2], $params);
                 if ($condition !== '') {
@@ -1327,22 +1582,26 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param array $tables
      * @param array $params
+     *
      * @return array
      */
     private function quoteTableNames($tables, &$params)
     {
         foreach ($tables as $i => $table) {
             if ($table instanceof Query) {
-                list($sql, $params) = $this->build($table, $params);
+                [$sql, $params] = $this->build($table, $params);
                 $tables[$i] = "($sql) " . $this->db->quoteTableName((string) $i);
             } elseif (is_string($i)) {
                 if (strpos($table, '(') === false) {
                     $table = $this->db->quoteTableName($table);
                 }
+
                 $tables[$i] = "$table " . $this->db->quoteTableName($i);
             } elseif (strpos($table, '(') === false) {
                 if ($tableWithAlias = $this->extractAlias($table)) { // with alias
-                    $tables[$i] = $this->db->quoteTableName($tableWithAlias[1]) . ' ' . $this->db->quoteTableName($tableWithAlias[2]);
+                    $tables[$i] = $this->db->quoteTableName($tableWithAlias[1])
+                        . ' '
+                        . $this->db->quoteTableName($tableWithAlias[2]);
                 } else {
                     $tables[$i] = $this->db->quoteTableName($table);
                 }
@@ -1355,6 +1614,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param string|array $condition
      * @param array $params the binding parameters to be populated
+     *
      * @return string the WHERE clause built from [[Query::$where]].
      */
     public function buildWhere($condition, &$params)
@@ -1366,6 +1626,7 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * @param array $columns
+     *
      * @return string the GROUP BY clause
      */
     public function buildGroupBy($columns)
@@ -1387,6 +1648,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param string|array $condition
      * @param array $params the binding parameters to be populated
+     *
      * @return string the HAVING clause built from [[Query::$having]].
      */
     public function buildHaving($condition, &$params)
@@ -1398,19 +1660,25 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Builds the ORDER BY and LIMIT/OFFSET clauses and appends them to the given SQL.
+     *
      * @param string $sql the existing SQL (without ORDER BY/LIMIT/OFFSET)
-     * @param array $orderBy the order by columns. See [[Query::orderBy]] for more details on how to specify this parameter.
+     * @param array $orderBy the order by columns. See [[Query::orderBy]] for more details on how to specify this
+     * parameter.
      * @param int $limit the limit number. See [[Query::limit]] for more details.
      * @param int $offset the offset number. See [[Query::offset]] for more details.
+     *
      * @return string the SQL completed with ORDER BY/LIMIT/OFFSET (if any)
      */
     public function buildOrderByAndLimit($sql, $orderBy, $limit, $offset)
     {
         $orderBy = $this->buildOrderBy($orderBy);
+
         if ($orderBy !== '') {
             $sql .= $this->separator . $orderBy;
         }
+
         $limit = $this->buildLimit($limit, $offset);
+
         if ($limit !== '') {
             $sql .= $this->separator . $limit;
         }
@@ -1427,7 +1695,9 @@ class QueryBuilder extends \yii\base\BaseObject
         if (empty($columns)) {
             return '';
         }
+
         $orders = [];
+
         foreach ($columns as $name => $direction) {
             if ($direction instanceof ExpressionInterface) {
                 $orders[] = $this->buildExpression($direction);
@@ -1442,16 +1712,19 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param int $limit
      * @param int $offset
+     *
      * @return string the LIMIT and OFFSET clauses
      */
     public function buildLimit($limit, $offset)
     {
         $sql = '';
+
         if ($this->hasLimit($limit)) {
-            $sql = 'LIMIT ' . $limit;
+            $sql = "LIMIT {$limit}";
         }
+
         if ($this->hasOffset($offset)) {
-            $sql .= ' OFFSET ' . $offset;
+            $sql .= " OFFSET {$offset}";
         }
 
         return ltrim($sql);
@@ -1459,7 +1732,9 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Checks to see if the given limit is effective.
+     *
      * @param mixed $limit the given limit
+     *
      * @return bool whether the limit is effective
      */
     protected function hasLimit($limit)
@@ -1469,7 +1744,9 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Checks to see if the given offset is effective.
+     *
      * @param mixed $offset the given offset
+     *
      * @return bool whether the offset is effective
      */
     protected function hasOffset($offset)
@@ -1480,6 +1757,7 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param array $unions
      * @param array $params the binding parameters to be populated
+     *
      * @return string the UNION clause built from [[Query::$union]].
      */
     public function buildUnion($unions, &$params)
@@ -1493,7 +1771,7 @@ class QueryBuilder extends \yii\base\BaseObject
         foreach ($unions as $i => $union) {
             $query = $union['query'];
             if ($query instanceof Query) {
-                list($unions[$i]['query'], $params) = $this->build($query, $params);
+                [$unions[$i]['query'], $params] = $this->build($query, $params);
             }
 
             $result .= 'UNION ' . ($union['all'] ? 'ALL ' : '') . '( ' . $unions[$i]['query'] . ' ) ';
@@ -1505,7 +1783,9 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * @param array $withs of configurations for each WITH query
      * @param array $params the binding parameters to be populated
+     *
      * @return string compiled WITH prefix of query including nested queries
+     *
      * @see Query::withQuery()
      * @since 2.0.35
      */
@@ -1520,8 +1800,8 @@ class QueryBuilder extends \yii\base\BaseObject
 
         foreach ($withs as $with) {
             $recursive = $with['recursive'] ?? $recursive;
-
             $query = $with['query'];
+
             if ($query instanceof Query) {
                 [$with['query'], $params] = $this->build($query, $params);
             }
@@ -1535,7 +1815,9 @@ class QueryBuilder extends \yii\base\BaseObject
     /**
      * Processes columns and properly quotes them if necessary.
      * It will join all columns into a string with comma as separators.
+     *
      * @param string|array $columns the columns to be processed
+     *
      * @return string the processing result
      */
     public function buildColumns($columns)
@@ -1546,7 +1828,9 @@ class QueryBuilder extends \yii\base\BaseObject
             }
 
             $rawColumns = $columns;
+
             $columns = preg_split('/\s*,\s*/', $columns, -1, PREG_SPLIT_NO_EMPTY);
+
             if ($columns === false) {
                 throw new InvalidArgumentException("$rawColumns is not valid columns.");
             }
@@ -1564,9 +1848,11 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Parses the condition specification and generates the corresponding SQL expression.
-     * @param string|array|ExpressionInterface $condition the condition specification. Please refer to [[Query::where()]]
-     * on how to specify a condition.
+     *
+     * @param string|array|ExpressionInterface $condition the condition specification.
+     * Please refer to [[Query::where()]] on how to specify a condition.
      * @param array $params the binding parameters to be populated
+     *
      * @return string the generated SQL expression
      */
     public function buildCondition($condition, &$params)
@@ -1587,12 +1873,13 @@ class QueryBuilder extends \yii\base\BaseObject
     }
 
     /**
-     * Transforms $condition defined in array format (as described in [[Query::where()]]
-     * to instance of [[yii\db\condition\ConditionInterface|ConditionInterface]] according to
-     * [[conditionClasses]] map.
+     * Transforms $condition defined in array format (as described in [[Query::where()]] to instance of
+     * [[yii\db\condition\ConditionInterface|ConditionInterface]] according to [[conditionClasses]] map.
      *
      * @param string|array $condition
+     *
      * @return ConditionInterface
+     *
      * @see conditionClasses
      * @since 2.0.14
      */
@@ -1600,11 +1887,13 @@ class QueryBuilder extends \yii\base\BaseObject
     {
         if (isset($condition[0])) { // operator format: operator, operand 1, operand 2, ...
             $operator = strtoupper(array_shift($condition));
+
             if (isset($this->conditionClasses[$operator])) {
                 $className = $this->conditionClasses[$operator];
             } else {
-                $className = 'yii\db\conditions\SimpleCondition';
+                $className = conditions\SimpleCondition::class;
             }
+
             /** @var ConditionInterface $className */
             return $className::fromArrayDefinition($operator, $condition);
         }
@@ -1614,147 +1903,17 @@ class QueryBuilder extends \yii\base\BaseObject
     }
 
     /**
-     * Creates a condition based on column-value pairs.
-     * @param array $condition the condition specification.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildHashCondition($condition, &$params)
-    {
-        return $this->buildCondition(new HashCondition($condition), $params);
-    }
-
-    /**
-     * Connects two or more SQL expressions with the `AND` or `OR` operator.
-     * @param string $operator the operator to use for connecting the given operands
-     * @param array $operands the SQL expressions to connect.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildAndCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Inverts an SQL expressions with `NOT` operator.
-     * @param string $operator the operator to use for connecting the given operands
-     * @param array $operands the SQL expressions to connect.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws InvalidArgumentException if wrong number of operands have been given.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildNotCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates an SQL expressions with the `BETWEEN` operator.
-     * @param string $operator the operator to use (e.g. `BETWEEN` or `NOT BETWEEN`)
-     * @param array $operands the first operand is the column name. The second and third operands
-     * describe the interval that column value should be in.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws InvalidArgumentException if wrong number of operands have been given.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildBetweenCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates an SQL expressions with the `IN` operator.
-     * @param string $operator the operator to use (e.g. `IN` or `NOT IN`)
-     * @param array $operands the first operand is the column name. If it is an array
-     * a composite IN condition will be generated.
-     * The second operand is an array of values that column value should be among.
-     * If it is an empty array the generated expression will be a `false` value if
-     * operator is `IN` and empty if operator is `NOT IN`.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws Exception if wrong number of operands have been given.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildInCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates an SQL expressions with the `LIKE` operator.
-     * @param string $operator the operator to use (e.g. `LIKE`, `NOT LIKE`, `OR LIKE` or `OR NOT LIKE`)
-     * @param array $operands an array of two or three operands
+     * Creates a `SELECT EXISTS()` SQL statement.
      *
-     * - The first operand is the column name.
-     * - The second operand is a single value or an array of values that column value
-     *   should be compared with. If it is an empty array the generated expression will
-     *   be a `false` value if operator is `LIKE` or `OR LIKE`, and empty if operator
-     *   is `NOT LIKE` or `OR NOT LIKE`.
-     * - An optional third operand can also be provided to specify how to escape special characters
-     *   in the value(s). The operand should be an array of mappings from the special characters to their
-     *   escaped counterparts. If this operand is not provided, a default escape mapping will be used.
-     *   You may use `false` or an empty array to indicate the values are already escaped and no escape
-     *   should be applied. Note that when using an escape mapping (or the third operand is not provided),
-     *   the values will be automatically enclosed within a pair of percentage characters.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws InvalidArgumentException if wrong number of operands have been given.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildLikeCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates an SQL expressions with the `EXISTS` operator.
-     * @param string $operator the operator to use (e.g. `EXISTS` or `NOT EXISTS`)
-     * @param array $operands contains only one element which is a [[Query]] object representing the sub-query.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws InvalidArgumentException if the operand is not a [[Query]] object.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildExistsCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates an SQL expressions like `"column" operator value`.
-     * @param string $operator the operator to use. Anything could be used e.g. `>`, `<=`, etc.
-     * @param array $operands contains two column names.
-     * @param array $params the binding parameters to be populated
-     * @return string the generated SQL expression
-     * @throws InvalidArgumentException if wrong number of operands have been given.
-     * @deprecated since 2.0.14. Use `buildCondition()` instead.
-     */
-    public function buildSimpleCondition($operator, $operands, &$params)
-    {
-        array_unshift($operands, $operator);
-        return $this->buildCondition($operands, $params);
-    }
-
-    /**
-     * Creates a SELECT EXISTS() SQL statement.
      * @param string $rawSql the subquery in a raw form to select from.
-     * @return string the SELECT EXISTS() SQL statement.
+     *
+     * @return string the `SELECT EXISTS()` SQL statement.
+     *
      * @since 2.0.8
      */
     public function selectExists($rawSql)
     {
-        return 'SELECT EXISTS(' . $rawSql . ')';
+        return "SELECT EXISTS($rawSql)";
     }
 
     /**
@@ -1762,6 +1921,7 @@ class QueryBuilder extends \yii\base\BaseObject
      *
      * @param string|null $value
      * @param array $params passed by reference
+     *
      * @return string the placeholder name in $params array
      *
      * @since 2.0.14
@@ -1769,6 +1929,7 @@ class QueryBuilder extends \yii\base\BaseObject
     public function bindParam($value, &$params)
     {
         $phName = self::PARAM_PREFIX . count($params);
+
         $params[$phName] = $value;
 
         return $phName;
@@ -1776,8 +1937,11 @@ class QueryBuilder extends \yii\base\BaseObject
 
     /**
      * Extracts table alias if there is one or returns false
-     * @param $table
+     *
+     * @param string $table
+     *
      * @return bool|array
+     *
      * @since 2.0.24
      */
     protected function extractAlias($table)


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
