### PR TITLE
refactor(db)!: remove 9 dead methods from `DataReader` (`bindColumn`,  `setFetchMode`, `readColumn`, `readObject`, `readAll`, `nextResult`, `getIsClosed`, `getRowCount`, `getColumnCount`); inline `rowCount()` into `count()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -76,3 +76,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(db)!: modernize base `QueryBuilder` remove deprecated `$conditionBuilders` and 8 `build*Condition()` methods; use `::class`, spread operator, short destructuring, `static` closures.
 - refactor(db)!: replace dynamic metadata dispatch with `MetadataType` enum and explicit `match`; fix MSSQL `'defaults'` cache key mismatch.
 - refactor(db)!: replace dynamic `queryInternal()` dispatch with `QueryMode` enum and explicit `match`; remove unused `$fetchMode` parameter from `queryAll()` and `queryOne()`.
+- refactor(db)!: remove 9 dead methods from `DataReader` (`bindColumn`, `setFetchMode`, `readColumn`, `readObject`, `readAll`, `nextResult`, `getIsClosed`, `getRowCount`, `getColumnCount`); inline `rowCount()` into `count()`.

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -555,6 +555,24 @@ The `MetadataType` enum cases have been renamed from PascalCase to UPPER_SNAKE_C
 **Action required** if your application references `MetadataType` enum cases directly. Update all references to use the
 new UPPER_SNAKE_CASE names. The backing string values remain unchanged (`'checks'`, `'primaryKey'`, etc.).
 
+### `DataReader` dead methods removed
+
+The following methods have been removed from `yii\db\DataReader` (zero production callers):
+
+| Removed method | Replacement |
+| --- | --- |
+| `bindColumn()` | Use `$command->pdoStatement->bindColumn()` directly |
+| `setFetchMode()` | Use `$command->fetchMode` property before calling `query()` |
+| `readColumn()` | Use `$command->queryColumn()` instead |
+| `readObject()` | Use `$command->pdoStatement->fetchObject()` directly |
+| `readAll()` | Use `$command->queryAll()` instead |
+| `nextResult()` | Use `$command->pdoStatement->nextRowset()` directly |
+| `getIsClosed()` | No replacement needed |
+| `getRowCount()` | Use `count($reader)` (Countable interface) |
+| `getColumnCount()` | Use `$command->pdoStatement->columnCount()` directly |
+
+The `@property-read` annotations for `$columnCount`, `$fetchMode`, `$isClosed`, and `$rowCount` have been removed.
+
 ### Base `QueryBuilder` deprecated API removal
 
 The following deprecated members of `yii\db\QueryBuilder` have been removed (all deprecated since 2.0.14):

--- a/src/db/DataReader.php
+++ b/src/db/DataReader.php
@@ -13,11 +13,10 @@ use yii\base\InvalidCallException;
 /**
  * DataReader represents a forward-only stream of rows from a query result set.
  *
- * To read the current row of data, call [[read()]]. The method [[readAll()]]
- * returns all the rows in a single array. Rows of data can also be read by
+ * To read the current row of data, call [[read()]]. Rows of data can also be read by
  * iterating through the reader. For example,
  *
- * ```
+ * ```php
  * $command = $connection->createCommand('SELECT * FROM post');
  * $reader = $command->query();
  *
@@ -29,22 +28,10 @@ use yii\base\InvalidCallException;
  * foreach ($reader as $row) {
  *     $rows[] = $row;
  * }
- *
- * // equivalent to:
- * $rows = $reader->readAll();
  * ```
  *
  * Note that since DataReader is a forward-only stream, you can only traverse it once.
  * Doing it the second time will throw an exception.
- *
- * It is possible to use a specific mode of data fetching by setting
- * [[fetchMode]]. See the [PHP manual](https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php)
- * for more details about possible fetch mode.
- *
- * @property-read int $columnCount The number of columns in the result set.
- * @property-write int $fetchMode Fetch mode.
- * @property-read bool $isClosed Whether the reader is closed or not.
- * @property-read int $rowCount Number of rows contained in the result.
  *
  * @author Qiang Xue <qiang.xue@gmail.com>
  * @since 2.0
@@ -56,109 +43,32 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
     /**
      * @var \PDOStatement the PDOStatement associated with the command
      */
-    private $_statement;
-    private $_closed = false;
-    private $_row;
-    private $_index = -1;
+    private \PDOStatement $_statement;
+    private bool $_closed = false;
+    private mixed $_row = null;
+    private int $_index = -1;
 
 
     /**
-     * Constructor.
-     * @param Command $command the command generating the query result
-     * @param array $config name-value pairs that will be used to initialize the object properties
+     * @param Command $command the command generating the query result.
+     * @param array $config name-value pairs that will be used to initialize the object properties.
      */
-    public function __construct(Command $command, $config = [])
+    public function __construct(Command $command, array $config = [])
     {
         $this->_statement = $command->pdoStatement;
         $this->_statement->setFetchMode(\PDO::FETCH_ASSOC);
+
         parent::__construct($config);
     }
 
     /**
-     * Binds a column to a PHP variable.
-     * When rows of data are being fetched, the corresponding column value
-     * will be set in the variable. Note, the fetch mode must include PDO::FETCH_BOUND.
-     * @param int|string $column Number of the column (1-indexed) or name of the column
-     * in the result set. If using the column name, be aware that the name
-     * should match the case of the column, as returned by the driver.
-     * @param mixed $value Name of the PHP variable to which the column will be bound.
-     * @param int|null $dataType Data type of the parameter
-     * @see https://www.php.net/manual/en/function.PDOStatement-bindColumn.php
-     */
-    public function bindColumn($column, &$value, $dataType = null)
-    {
-        if ($dataType === null) {
-            $this->_statement->bindColumn($column, $value);
-        } else {
-            $this->_statement->bindColumn($column, $value, $dataType);
-        }
-    }
-
-    /**
-     * Set the default fetch mode for this statement.
-     *
-     * @param int $mode fetch mode
-     * @see https://www.php.net/manual/en/function.PDOStatement-setFetchMode.php
-     */
-    public function setFetchMode($mode)
-    {
-        $params = func_get_args();
-        call_user_func_array([$this->_statement, 'setFetchMode'], $params);
-    }
-
-    /**
      * Advances the reader to the next row in a result set.
-     * @return array|false the current row, false if no more row available
+     *
+     * @return array|false the current row, false if no more row available.
      */
-    public function read()
+    public function read(): array|false
     {
         return $this->_statement->fetch();
-    }
-
-    /**
-     * Returns a single column from the next row of a result set.
-     * @param int $columnIndex zero-based column index
-     * @return mixed the column of the current row, false if no more rows available
-     */
-    public function readColumn($columnIndex)
-    {
-        return $this->_statement->fetchColumn($columnIndex);
-    }
-
-    /**
-     * Returns an object populated with the next row of data.
-     * @param string $className class name of the object to be created and populated
-     * @param array $fields Elements of this array are passed to the constructor
-     * @return mixed the populated object, false if no more row of data available
-     */
-    public function readObject($className, $fields)
-    {
-        return $this->_statement->fetchObject($className, $fields);
-    }
-
-    /**
-     * Reads the whole result set into an array.
-     * @return array the result set (each array element represents a row of data).
-     * An empty array will be returned if the result contains no row.
-     */
-    public function readAll()
-    {
-        return $this->_statement->fetchAll();
-    }
-
-    /**
-     * Advances the reader to the next result when reading the results of a batch of statements.
-     * This method is only useful when there are multiple result sets
-     * returned by the query. Not all DBMS support this feature.
-     * @return bool Returns true on success or false on failure.
-     */
-    public function nextResult()
-    {
-        if (($result = $this->_statement->nextRowset()) !== false) {
-            $this->_index = -1;
-        }
-
-        return $result;
     }
 
     /**
@@ -166,30 +76,10 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This frees up the resources allocated for executing this SQL statement.
      * Read attempts after this method call are unpredictable.
      */
-    public function close()
+    public function close(): void
     {
         $this->_statement->closeCursor();
         $this->_closed = true;
-    }
-
-    /**
-     * whether the reader is closed or not.
-     * @return bool whether the reader is closed or not.
-     */
-    public function getIsClosed()
-    {
-        return $this->_closed;
-    }
-
-    /**
-     * Returns the number of rows in the result set.
-     * Note, most DBMS may not give a meaningful count.
-     * In this case, use "SELECT COUNT(*) FROM tableName" to obtain the number of rows.
-     * @return int number of rows contained in the result.
-     */
-    public function getRowCount()
-    {
-        return $this->_statement->rowCount();
     }
 
     /**
@@ -197,31 +87,21 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * This method is required by the Countable interface.
      * Note, most DBMS may not give a meaningful count.
      * In this case, use "SELECT COUNT(*) FROM tableName" to obtain the number of rows.
+     *
      * @return int number of rows contained in the result.
      */
-    #[\ReturnTypeWillChange]
-    public function count()
+    public function count(): int
     {
-        return $this->getRowCount();
-    }
-
-    /**
-     * Returns the number of columns in the result set.
-     * Note, even there's no row in the reader, this still gives correct column number.
-     * @return int the number of columns in the result set.
-     */
-    public function getColumnCount()
-    {
-        return $this->_statement->columnCount();
+        return $this->_statement->rowCount();
     }
 
     /**
      * Resets the iterator to the initial state.
      * This method is required by the interface [[\Iterator]].
-     * @throws InvalidCallException if this method is invoked twice
+     *
+     * @throws InvalidCallException if this method is invoked twice.
      */
-    #[\ReturnTypeWillChange]
-    public function rewind()
+    public function rewind(): void
     {
         if ($this->_index < 0) {
             $this->_row = $this->_statement->fetch();
@@ -234,10 +114,10 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
     /**
      * Returns the index of the current row.
      * This method is required by the interface [[\Iterator]].
+     *
      * @return int the index of the current row.
      */
-    #[\ReturnTypeWillChange]
-    public function key()
+    public function key(): int
     {
         return $this->_index;
     }
@@ -245,10 +125,10 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
     /**
      * Returns the current row.
      * This method is required by the interface [[\Iterator]].
+     *
      * @return mixed the current row.
      */
-    #[\ReturnTypeWillChange]
-    public function current()
+    public function current(): mixed
     {
         return $this->_row;
     }
@@ -257,8 +137,7 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
      * Moves the internal pointer to the next row.
      * This method is required by the interface [[\Iterator]].
      */
-    #[\ReturnTypeWillChange]
-    public function next()
+    public function next(): void
     {
         $this->_row = $this->_statement->fetch();
         $this->_index++;
@@ -267,10 +146,10 @@ class DataReader extends \yii\base\BaseObject implements \Iterator, \Countable
     /**
      * Returns whether there is a row of data at current position.
      * This method is required by the interface [[\Iterator]].
+     *
      * @return bool whether there is a row of data at current position.
      */
-    #[\ReturnTypeWillChange]
-    public function valid()
+    public function valid(): bool
     {
         return $this->_row !== false;
     }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ✔️                                                              |
