### PR TITLE
fix(db/oci): `findUniqueIndexes()` returns empty results when `PDO::ATTR_CASE` is `PDO::CASE_LOWER` due to missing `normalizePdoRowKeyCase()` call.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,3 +78,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(db)!: replace dynamic `queryInternal()` dispatch with `QueryMode` enum and explicit `match`; remove unused `$fetchMode` parameter from `queryAll()` and `queryOne()`.
 - refactor(db)!: remove 9 dead methods from `DataReader` (`bindColumn`, `setFetchMode`, `readColumn`, `readObject`, `readAll`, `nextResult`, `getIsClosed`, `getRowCount`, `getColumnCount`); inline `rowCount()` into `count()`.
 - test(db): Raise code coverage to `100%` for `DataReader` classes across all drivers.
+- fix(db/oci): `findUniqueIndexes()` returns empty results when `PDO::ATTR_CASE` is `PDO::CASE_LOWER` due to missing `normalizePdoRowKeyCase()` call.

--- a/src/db/oci/Schema.php
+++ b/src/db/oci/Schema.php
@@ -590,8 +590,8 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
     {
         $query = <<<SQL
             SELECT
-                "dic"."INDEX_NAME",
-                "dic"."COLUMN_NAME"
+                "dic"."INDEX_NAME" AS "index_name",
+                "dic"."COLUMN_NAME" AS "column_name"
             FROM "ALL_INDEXES" "di"
             INNER JOIN "ALL_IND_COLUMNS" "dic"
                 ON "dic"."INDEX_OWNER" = "di"."OWNER"
@@ -614,8 +614,10 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             ],
         );
 
-        foreach ($command->queryAll() as $row) {
-            $result[$row['INDEX_NAME']][] = $row['COLUMN_NAME'];
+        $rows = $this->normalizePdoRowKeyCase($command->queryAll(), true);
+
+        foreach ($rows as $row) {
+            $result[$row['index_name']][] = $row['column_name'];
         }
 
         return $result;


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
