### PR TITLE
fix(db/oci): `findColumns()` blanket `catch (Exception)` silently swallows connection and permission errors; remove try/catch since Oracle catalog views return empty results for non-existent tables.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,3 +79,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(db)!: remove 9 dead methods from `DataReader` (`bindColumn`, `setFetchMode`, `readColumn`, `readObject`, `readAll`, `nextResult`, `getIsClosed`, `getRowCount`, `getColumnCount`); inline `rowCount()` into `count()`.
 - test(db): Raise code coverage to `100%` for `DataReader` classes across all drivers.
 - fix(db/oci): `findUniqueIndexes()` returns empty results when `PDO::ATTR_CASE` is `PDO::CASE_LOWER` due to missing `normalizePdoRowKeyCase()` call.
+- fix(db/oci): `findColumns()` blanket `catch (Exception)` silently swallows connection and permission errors; remove try/catch since Oracle catalog views return empty results for non-existent tables.

--- a/src/db/oci/Schema.php
+++ b/src/db/oci/Schema.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace yii\db\oci;
 
-use Exception;
 use PDO;
 use Yii;
 use yii\base\InvalidCallException;
@@ -353,17 +352,13 @@ class Schema extends \yii\db\Schema implements ConstraintFinderInterface
             ORDER BY "a"."COLUMN_ID"
             SQL;
 
-        try {
-            $columns = $this->db->createCommand(
-                $sql,
-                [
-                    ':tableName' => $table->name,
-                    ':schemaName' => $table->schemaName,
-                ],
-            )->queryAll();
-        } catch (Exception $e) {
-            return false;
-        }
+        $columns = $this->db->createCommand(
+            $sql,
+            [
+                ':tableName' => $table->name,
+                ':schemaName' => $table->schemaName,
+            ],
+        )->queryAll();
 
         if (empty($columns)) {
             return false;


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
