### PR TITLE
test(db/mysql): add regression cases for `bit(32)` and `bit(33+)` to `ColumnSchemaProvider`; covers the `integer` and `bigint` boundary branches in `Schema::loadColumnSchema()`.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,3 +81,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(db/oci): `findUniqueIndexes()` returns empty results when `PDO::ATTR_CASE` is `PDO::CASE_LOWER` due to missing `normalizePdoRowKeyCase()` call.
 - fix(db/oci): `findColumns()` blanket `catch (Exception)` silently swallows connection and permission errors; remove try/catch since Oracle catalog views return empty results for non-existent tables.
 - fix(db/mysql): use quote-aware parser for MySQL enum column literals in `ColumnSchema::extractSizeFromDbType()`; fixes corrupted `enumValues` for definitions containing parentheses or escaped single quotes.
+- test(db/mysql): add regression cases for `bit(32)` and `bit(33+)` to `ColumnSchemaProvider`; covers the `integer` and `bigint` boundary branches in `Schema::loadColumnSchema()`.

--- a/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/mysql/providers/ColumnSchemaProvider.php
@@ -42,6 +42,20 @@ final class ColumnSchemaProvider
                 "b'10101'",
                 21,
             ],
+            'bit(32) default b\'10000000000000000000000000000001\'' => [
+                'integer',
+                'bit(32)',
+                'integer',
+                "b'10000000000000000000000000000001'",
+                2147483649,
+            ],
+            'bit(33) default b\'100000000000000000000000000000001\'' => [
+                'bigint',
+                'bit(33)',
+                'integer',
+                "b'100000000000000000000000000000001'",
+                4294967297,
+            ],
             'current_timestamp() on timestamp column (MariaDB format)' => [
                 'timestamp',
                 'timestamp',


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
