### PR TITLE
fix(db/sqlite): `bit(17)`–`bit(32)` columns incorrectly mapped to `smallint` instead of `integer` in `Schema::loadColumnSchema()`; complete the BIT size-range mapping for all width boundaries.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,3 +82,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - fix(db/oci): `findColumns()` blanket `catch (Exception)` silently swallows connection and permission errors; remove try/catch since Oracle catalog views return empty results for non-existent tables.
 - fix(db/mysql): use quote-aware parser for MySQL enum column literals in `ColumnSchema::extractSizeFromDbType()`; fixes corrupted `enumValues` for definitions containing parentheses or escaped single quotes.
 - test(db/mysql): add regression cases for `bit(32)` and `bit(33+)` to `ColumnSchemaProvider`; covers the `integer` and `bigint` boundary branches in `Schema::loadColumnSchema()`.
+- fix(db/sqlite): `bit(17)`–`bit(32)` columns incorrectly mapped to `smallint` instead of `integer` in `Schema::loadColumnSchema()`; complete the BIT size-range mapping for all width boundaries.

--- a/src/db/ColumnSchema.php
+++ b/src/db/ColumnSchema.php
@@ -8,6 +8,7 @@
 
 namespace yii\db;
 
+use PDO;
 use yii\base\BaseObject;
 use yii\helpers\StringHelper;
 
@@ -80,12 +81,13 @@ class ColumnSchema extends BaseObject
      */
     public string|null $comment = null;
 
-
     /**
      * Converts the input value according to [[phpType]] after retrieval from the database.
      * If the value is null or an [[Expression]], it will not be converted.
-     * @param mixed $value input value
-     * @return mixed converted value
+     *
+     * @param mixed $value input value.
+     *
+     * @return mixed converted value.
      */
     public function phpTypecast($value)
     {
@@ -144,11 +146,29 @@ class ColumnSchema extends BaseObject
     }
 
     /**
+     * Refines the abstract column type based on driver-specific size and width rules.
+     *
+     * Called by `Schema::loadColumnSchema()` after the initial type is resolved from the `typeMap`. The base
+     * implementation is a no-op. Driver subclasses override this method to remap types that depend on the column size
+     * (for example, BIT width boundaries, `tinyint(1)` → `boolean`).
+     *
+     * @param string $type the base database type name returned by {@see extractSizeFromDbType()} (for example, `bit`,
+     * `tinyint`).
+     *
+     * @since 2.2
+     */
+    public function resolveType(string $type): void
+    {
+    }
+
+    /**
      * Converts the input value according to [[type]] and [[dbType]] for use in a db query.
      * If the value is null or an [[Expression]], it will not be converted.
-     * @param mixed $value input value
-     * @return mixed converted value. This may also be an array containing the value as the first element
-     * and the PDO type as the second element.
+     *
+     * @param mixed $value input value.
+     *
+     * @return mixed converted value. This may also be an array containing the value as the first element and the PDO
+     * type as the second element.
      */
     public function dbTypecast($value)
     {
@@ -160,8 +180,11 @@ class ColumnSchema extends BaseObject
     /**
      * Converts the input value according to [[phpType]] after retrieval from the database.
      * If the value is null or an [[Expression]], it will not be converted.
-     * @param mixed $value input value
-     * @return mixed converted value
+     *
+     * @param mixed $value input value.
+     *
+     * @return mixed converted value.
+     *
      * @since 2.0.3
      */
     protected function typecast($value)
@@ -240,10 +263,10 @@ class ColumnSchema extends BaseObject
     }
 
     /**
-     * @return int[] array of numbers that represent possible PDO parameter types
+     * @return int[] array of numbers that represent possible PDO parameter types.
      */
     private function getPdoParamTypes()
     {
-        return [\PDO::PARAM_BOOL, \PDO::PARAM_INT, \PDO::PARAM_STR, \PDO::PARAM_LOB, \PDO::PARAM_NULL, \PDO::PARAM_STMT];
+        return [PDO::PARAM_BOOL, PDO::PARAM_INT, PDO::PARAM_STR, PDO::PARAM_LOB, PDO::PARAM_NULL, PDO::PARAM_STMT];
     }
 }

--- a/src/db/sqlite/ColumnSchema.php
+++ b/src/db/sqlite/ColumnSchema.php
@@ -20,7 +20,8 @@ use function trim;
 /**
  * Represents the metadata of a column in a SQLite database table.
  *
- * Extends the base {@see \yii\db\ColumnSchema} with SQLite-specific default value handling:
+ * Extends the base {@see \yii\db\ColumnSchema} with SQLite-specific handling:
+ * - Resolves BIT size ranges to the correct abstract type (`boolean`, `smallint`, `integer`, `bigint`).
  * - Normalizes `null`, empty string, and `'null'` literals to `null`.
  * - Converts `CURRENT_TIMESTAMP` defaults on timestamp columns to {@see Expression} instances.
  * - Strips surrounding single/double-quote wrappers from string defaults.
@@ -30,6 +31,28 @@ use function trim;
  */
 class ColumnSchema extends \yii\db\ColumnSchema
 {
+    /**
+     * {@inheritdoc}
+     *
+     * Handles `tinyint(1)` and BIT width boundaries:
+     * - `tinyint(1)` or `bit(1)` → `boolean`.
+     * - `bit(2)`–`bit(16)` → unchanged (remains `smallint` from `typeMap`).
+     * - `bit(17)`–`bit(32)` → `integer`.
+     * - `bit(33+)` → `bigint`.
+     */
+    public function resolveType(string $type): void
+    {
+        if ($this->size === 1 && ($type === 'tinyint' || $type === 'bit')) {
+            $this->type = 'boolean';
+        } elseif ($type === 'bit') {
+            if ($this->size > 32) {
+                $this->type = 'bigint';
+            } elseif ($this->size > 16) {
+                $this->type = 'integer';
+            }
+        }
+    }
+
     /**
      * Converts a SQLite column default value to its PHP representation.
      *

--- a/src/db/sqlite/Schema.php
+++ b/src/db/sqlite/Schema.php
@@ -396,15 +396,7 @@ class Schema extends BaseSchema implements ConstraintFinderInterface
 
         $column->type = $this->typeMap[$type] ?? self::TYPE_STRING;
 
-        if ($column->size === 1 && ($type === 'tinyint' || $type === 'bit')) {
-            $column->type = 'boolean';
-        } elseif ($type === 'bit') {
-            if ($column->size > 32) {
-                $column->type = 'bigint';
-            } elseif ($column->size === 32) {
-                $column->type = 'integer';
-            }
-        }
+        $column->resolveType($type);
 
         $column->phpType = $this->getColumnPhpType($column);
 

--- a/tests/framework/db/sqlite/ColumnSchemaTest.php
+++ b/tests/framework/db/sqlite/ColumnSchemaTest.php
@@ -20,11 +20,6 @@ use yiiunit\framework\db\sqlite\providers\ColumnSchemaProvider;
 /**
  * Unit tests for {@see ColumnSchema} with SQLite driver.
  *
- * Test coverage.
- * - Converts `CURRENT_TIMESTAMP` defaults on timestamp columns to `Expression` instances.
- * - Normalizes `null`, empty, and `'null'` defaults to `null`.
- * - Strips surrounding quotes from string defaults and delegates to parent type casting.
- *
  * {@see ColumnSchemaProvider} for test case data providers.
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>

--- a/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
+++ b/tests/framework/db/sqlite/providers/ColumnSchemaProvider.php
@@ -15,7 +15,8 @@ use yii\db\Expression;
 /**
  * Data provider for {@see \yiiunit\framework\db\sqlite\ColumnSchemaTest} test cases.
  *
- * Provides representative input/output pairs for the SQLite `defaultPhpTypecast()` method.
+ * Provides representative input/output pairs for the SQLite `defaultPhpTypecast()` method, including BIT size-range
+ * boundary cases (`boolean`, `smallint`, `integer`, `bigint`).
  *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 2.2
@@ -28,6 +29,48 @@ final class ColumnSchemaProvider
     public static function defaultPhpTypecast(): array
     {
         return [
+            'bit(1) maps to boolean' => [
+                'boolean',
+                'bit(1)',
+                'boolean',
+                '1',
+                true,
+            ],
+            'bit(5) maps to smallint' => [
+                'smallint',
+                'bit(5)',
+                'integer',
+                '21',
+                21,
+            ],
+            'bit(16) maps to smallint (upper boundary)' => [
+                'smallint',
+                'bit(16)',
+                'integer',
+                '65535',
+                65535,
+            ],
+            'bit(17) maps to integer (lower boundary)' => [
+                'integer',
+                'bit(17)',
+                'integer',
+                '131071',
+                131071,
+            ],
+            'bit(32) maps to integer (upper boundary)' => [
+                'integer',
+                'bit(32)',
+                'integer',
+                '2147483649',
+                2147483649,
+            ],
+            'bit(33) maps to bigint' => [
+                'bigint',
+                'bit(33)',
+                'integer',
+                '4294967297',
+                4294967297,
+            ],
             'boolean false default (0)' => [
                 'boolean',
                 'tinyint(1)',


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
