### PR TITLE
fix(widgets): clear stale AJAX validation errors for dependent fields when later responses omit previously invalid attributes.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -90,3 +90,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - refactor(db)!: move savepoint and isolation-level operations from `Schema` to `Transaction`; replace constants with `TransactionIsolationLevel` enum.
 - chore(db): standardize PHPDoc and code style across `Schema` base class and all driver subclasses.
 - fix(db): `loadDefaultValues()` ignores default values for non-autoincrement composite primary key columns; check `autoIncrement` before nullifying defaults in all five drivers.
+- fix(widgets): clear stale AJAX validation errors for dependent fields when later responses omit previously invalid attributes.

--- a/src/assets/yii.activeForm.js
+++ b/src/assets/yii.activeForm.js
@@ -651,7 +651,7 @@
         });
         if (hasValueChanges) {
             $.each(data.attributes, function () {
-                if (!this.hasWhenClient || this.status === 2 || this.status === 3) {
+                if ((!this.hasWhenClient && !this.enableAjaxValidation) || this.status === 2 || this.status === 3) {
                     return;
                 }
                 if (hasValidationError($form, this, data)) {

--- a/tests/js/tests/yii.activeForm.test.js
+++ b/tests/js/tests/yii.activeForm.test.js
@@ -185,11 +185,74 @@ describe('yii.activeForm', function () {
                     ajaxStub.restore();
                 });
             });
+
+            describe('with dependent fields', function () {
+                it('should clear stale errors when an ajax response no longer contains a previously invalid field', function () {
+                    $activeForm = $('#w4');
+                    $activeForm.yiiActiveForm('destroy');
+                    $activeForm.yiiActiveForm([{
+                        id: 'test-att1',
+                        input: '#test-att1',
+                        container: '.field-test-att1',
+                        enableAjaxValidation: true
+                    }, {
+                        id: 'test-att2',
+                        input: '#test-att2',
+                        container: '.field-test-att2',
+                        enableAjaxValidation: true
+                    }], {
+                        validationUrl: ''
+                    });
+
+                    var requests = [];
+                    function fakeAjax(object) {
+                        var request = {
+                            jqXHR: {
+                                abort: function () {
+                                    request.aborted = true;
+                                },
+                                getResponseHeader: function () {
+                                    return null;
+                                }
+                            },
+                            aborted: false,
+                            respond: function (response) {
+                                if (this.aborted) {
+                                    return;
+                                }
+                                object.success(response);
+                                object.complete(this.jqXHR, '');
+                            }
+                        };
+                        requests.push(request);
+                        object.beforeSend(request.jqXHR, '');
+                    }
+
+                    var ajaxStub = sinon.stub($, 'ajax', fakeAjax);
+                    var $dependentField = $activeForm.find('.field-test-att1');
+
+                    $('#test-att1').val('');
+                    $activeForm.yiiActiveForm('validateAttribute', 'test-att1');
+                    assert.strictEqual(requests.length, 1);
+                    requests[0].respond({'test-att1': ['Att1 cannot be blank.']});
+                    assert.isTrue($dependentField.hasClass('has-error'));
+
+                    $('#test-att2').val('1');
+                    $activeForm.yiiActiveForm('validateAttribute', 'test-att2');
+                    assert.strictEqual(requests.length, 2);
+                    requests[1].respond({});
+
+                    assert.isFalse($dependentField.hasClass('has-error'));
+                    assert.equal('', $dependentField.find('.help-block').text());
+                    ajaxStub.restore();
+                });
+            });
         });
 
         describe('with conditional validation', function () {
             it('should clear stale errors for conditional attributes when related input changes', function () {
                 $activeForm = $('#w4');
+                $activeForm.yiiActiveForm('destroy');
                 $activeForm.yiiActiveForm([{
                     id: 'test-att1',
                     input: '#test-att1',


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
