### PR TITLE
fix: add `@template` generics to `ClientScriptInterface<T of BaseObject>` and `ClientValidatorScriptInterface<T of Validator>` for PHPStan inference in implementations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -97,3 +97,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore(tests): split monolithic `HtmlTest` into six focused test classes (`HtmlTagTest`, `HtmlFormTest`, `HtmlInputTest`, `HtmlListTest`, `HtmlAttributeTest`, `HtmlActiveTest`) with dedicated providers and keyed datasets.
 - fix(grid): `CheckboxColumn` now submits an empty unselect value by default when all row checkboxes are cleared, aligns hidden-input `form`/`disabled` attributes with checkbox options, and allows opt-out via `unselect = null`.
 - build!: extract jQuery integration layer into the `yii2-framework/jquery` package; `JqueryAsset`, all validator and widget client scripts, and jQuery-specific assets are no longer shipped with core.
+- fix: add `@template` generics to `ClientScriptInterface<T of BaseObject>` and `ClientValidatorScriptInterface<T of Validator>` for PHPStan inference in implementations.

--- a/src/validators/client/ClientValidatorScriptInterface.php
+++ b/src/validators/client/ClientValidatorScriptInterface.php
@@ -22,6 +22,8 @@ use yii\web\View;
  *
  * This allows decoupling validators from any particular client-side library.
  *
+ * @template T of Validator
+ *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 2.2
  */
@@ -30,21 +32,23 @@ interface ClientValidatorScriptInterface
     /**
      * Returns the client-side validation options for the given validator.
      *
-     * @param Validator $validator the validator instance.
-     * @param Model $model the data model being validated.
-     * @param string $attribute the attribute name being validated.
-     * @return array the client-side validation options.
+     * @param T $validator The validator instance.
+     * @param Model $model The data model being validated.
+     * @param string $attribute The attribute name being validated.
+     *
+     * @return array The client-side validation options.
      */
     public function getClientOptions(Validator $validator, Model $model, string $attribute): array;
 
     /**
      * Returns the JavaScript code needed for performing client-side validation.
      *
-     * @param Validator $validator the validator instance.
-     * @param Model $model the data model being validated.
-     * @param string $attribute the attribute name being validated.
-     * @param View $view the view object that is going to be used to render views or view files.
-     * @return string|null the client-side validation script, or `null` if not supported.
+     * @param T $validator The validator instance.
+     * @param Model $model The data model being validated.
+     * @param string $attribute The attribute name being validated.
+     * @param View $view The view object that is going to be used to render views or view files.
+     *
+     * @return string|null The client-side validation script, or `null` if not supported.
      */
     public function register(Validator $validator, Model $model, string $attribute, View $view): ?string;
 }

--- a/src/web/client/ClientScriptInterface.php
+++ b/src/web/client/ClientScriptInterface.php
@@ -21,6 +21,8 @@ use yii\web\View;
  *
  * This allows decoupling widgets from any particular client-side library.
  *
+ * @template T of BaseObject
+ *
  * @author Wilmer Arambula <terabytesoftw@gmail.com>
  * @since 2.2
  */
@@ -29,18 +31,19 @@ interface ClientScriptInterface
     /**
      * Returns the client-side options for the given widget.
      *
-     * @param BaseObject $widget the widget instance.
-     * @param array $params additional parameters.
-     * @return array the client-side options.
+     * @param T $widget The widget instance.
+     * @param array $params Additional parameters.
+     *
+     * @return array The client-side options.
      */
     public function getClientOptions(BaseObject $widget, array $params = []): array;
 
     /**
      * Registers the JavaScript code needed for the widget.
      *
-     * @param BaseObject $widget the widget instance.
-     * @param View $view the view object.
-     * @param array $params additional parameters.
+     * @param T $widget The widget instance.
+     * @param View $view The view object.
+     * @param array $params Additional parameters.
      */
     public function register(BaseObject $widget, View $view, array $params = []): void;
 }


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
