### PR TITLE
chore!: bump minimum PHP to `8.3` and upgrade PHPUnit to `^11.5`; and remove `dms/phpunit-arraysubset-asserts`.

### DIFF
--- a/.github/actions/phpunit/action.yml
+++ b/.github/actions/phpunit/action.yml
@@ -92,7 +92,12 @@ runs:
         add_param "--configuration" "$CONFIG_INPUT"
         add_param "--testsuite" "$SUITE_INPUT"
         add_param "--group" "$GROUP_INPUT"
-        add_param "--exclude-group" "$EXCLUDE_GROUP_INPUT"
+
+        if [ -n "$EXCLUDE_GROUP_INPUT" ]; then
+          for group in $EXCLUDE_GROUP_INPUT; do
+            PHPUNIT_CMD="$PHPUNIT_CMD --exclude-group $group"
+          done
+        fi
 
         if [ -n "$DEBUG_INPUT" ]; then
           PHPUNIT_CMD="$PHPUNIT_CMD $DEBUG_INPUT"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php: [8.2, 8.3, 8.4, 8.5]
+        php: [8.3, 8.4, 8.5]
 
     steps: &build-steps
       - name: Checkout.

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ concurrency:
 env:
   PHP_EXTENSIONS: curl, dom, imagick, intl, mbstring, mcrypt, memcached
   PHP_INI_VALUES: apc.enabled=1,apc.shm_size=32M,apc.enable_cli=1, date.timezone='UTC'
-  PHPUNIT_EXCLUDE_GROUP: db,wincache
+  PHPUNIT_EXCLUDE_GROUP: db wincache
   XDEBUG_MODE: coverage
 
 jobs:

--- a/.github/workflows/ci-mariadb.yml
+++ b/.github/workflows/ci-mariadb.yml
@@ -69,5 +69,5 @@ jobs:
       extensions: curl, intl, pdo, pdo_mysql
       os: '["ubuntu-22.04"]'
       php-ini-values: date.timezone='UTC', opcache.jit=tracing, opcache.jit_buffer_size=64M
-      php-version: '["8.2","8.3","8.4"]'
+      php-version: '["8.3","8.4"]'
       phpunit-group: mysql

--- a/.github/workflows/ci-mssql.yml
+++ b/.github/workflows/ci-mssql.yml
@@ -83,5 +83,5 @@ jobs:
           -Q "IF DB_ID(N'yiitest') IS NULL CREATE DATABASE yiitest;"
       os: '["ubuntu-22.04"]'
       php-ini-values: date.timezone='UTC', opcache.jit=tracing, opcache.jit_buffer_size=64M
-      php-version: '["8.2","8.3","8.4"]'
+      php-version: '["8.3","8.4"]'
       phpunit-group: mssql

--- a/.github/workflows/ci-mysql.yml
+++ b/.github/workflows/ci-mysql.yml
@@ -69,5 +69,5 @@ jobs:
       extensions: curl, intl, pdo, pdo_mysql
       os: '["ubuntu-22.04"]'
       php-ini-values: date.timezone='UTC', opcache.jit=tracing, opcache.jit_buffer_size=64M
-      php-version: '["8.2","8.3","8.4"]'
+      php-version: '["8.3","8.4"]'
       phpunit-group: mysql

--- a/.github/workflows/ci-oracle.yml
+++ b/.github/workflows/ci-oracle.yml
@@ -51,7 +51,7 @@ jobs:
       extensions: curl, intl, oci8, pdo, pdo_oci
       hook: docker exec -i database sqlplus -s system/oracle@//localhost/FREE < tests/data/oci/optimize_for_tests.sql
       os: '["ubuntu-22.04"]'
-      php-version: '["8.2","8.5"]'
+      php-version: '["8.3","8.5"]'
       phpunit-group: oci
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci-pgsql.yml
+++ b/.github/workflows/ci-pgsql.yml
@@ -69,5 +69,5 @@ jobs:
       extensions: curl, intl, pdo, pdo_pgsql
       os: '["ubuntu-22.04"]'
       php-ini-values: date.timezone='UTC', opcache.jit=tracing, opcache.jit_buffer_size=64M
-      php-version: '["8.2","8.3","8.4"]'
+      php-version: '["8.3","8.4"]'
       phpunit-group: pgsql

--- a/.github/workflows/ci-sqlite.yml
+++ b/.github/workflows/ci-sqlite.yml
@@ -59,5 +59,5 @@ jobs:
       extensions: curl, intl, pdo, pdo_sqlite
       os: '["ubuntu-22.04"]'
       php-ini-values: date.timezone='UTC', opcache.jit=tracing, opcache.jit_buffer_size=64M
-      php-version: '["8.2","8.3","8.4"]'
+      php-version: '["8.3","8.4"]'
       phpunit-group: sqlite

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,3 +107,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - chore: update references to the yii2 package in documentation and class maps; improve clarity in comments and `README.md`.
 - chore: remove unused dependency on `php-forge/foxy` from `composer.json`.
 - chore: remove redundant implicit dependencies on `ext-ctype` and `lib-pcre` from `composer.json`.
+- chore!: bump minimum PHP to `8.3` and upgrade PHPUnit to `^11.5`; and remove `dms/phpunit-arraysubset-asserts`.

--- a/composer.json
+++ b/composer.json
@@ -10,20 +10,19 @@
     ],
     "license": "BSD-3-Clause",
     "require": {
-        "php": ">=8.2",
+        "php": ">=8.3",
         "ext-mbstring": "*",
         "cebe/markdown": "^1.2.0",
         "ezyang/htmlpurifier": "^4.17",
         "yiisoft/yii2-composer": "~2.0.4"
     },
     "require-dev": {
-        "dms/phpunit-arraysubset-asserts": "^0.5",
         "infection/infection": "^0.32",
         "maglnet/composer-require-checker": "^4.1",
         "php-forge/coding-standard": "^0.1",
         "phpstan/extension-installer": "^1.4",
         "phpstan/phpstan-strict-rules": "^2.0.3",
-        "phpunit/phpunit": "^10.5",
+        "phpunit/phpunit": "^11.5",
         "xepozz/internal-mocker": "^1.4",
         "yii2-extensions/phpstan": "^0.4"
     },

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -5251,12 +5251,6 @@ parameters:
 			path: tests/base/db/BaseCommand.php
 
 		-
-			message: '#^Offset 0 does not exist on array\{\}\.$#'
-			identifier: offsetAccess.notFound
-			count: 8
-			path: tests/base/db/BaseCommand.php
-
-		-
 			message: '#^Only booleans are allowed in an if condition, yii\\db\\TableSchema\|null given\.$#'
 			identifier: if.condNotBoolean
 			count: 2
@@ -5674,12 +5668,6 @@ parameters:
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertTrue\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 5
-			path: tests/framework/BaseYiiTest.php
-
-		-
-			message: '#^Dynamic call to static method PHPUnit\\Framework\\TestCase\:\:exactly\(\)\.$#'
-			identifier: staticMethod.dynamicCall
-			count: 1
 			path: tests/framework/BaseYiiTest.php
 
 		-
@@ -6295,12 +6283,6 @@ parameters:
 			path: tests/framework/behaviors/CacheableWidgetBehaviorTest.php
 
 		-
-			message: '#^Dynamic call to static method PHPUnit\\Framework\\TestCase\:\:once\(\)\.$#'
-			identifier: staticMethod.dynamicCall
-			count: 3
-			path: tests/framework/behaviors/CacheableWidgetBehaviorTest.php
-
-		-
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertEquals\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 23
@@ -6832,24 +6814,6 @@ parameters:
 			message: '#^Dynamic call to static method PHPUnit\\Framework\\Assert\:\:assertStringContainsString\(\)\.$#'
 			identifier: staticMethod.dynamicCall
 			count: 10
-			path: tests/framework/console/controllers/ServeControllerTest.php
-
-		-
-			message: '#^Dynamic call to static method PHPUnit\\Framework\\TestCase\:\:any\(\)\.$#'
-			identifier: staticMethod.dynamicCall
-			count: 2
-			path: tests/framework/console/controllers/ServeControllerTest.php
-
-		-
-			message: '#^Dynamic call to static method PHPUnit\\Framework\\TestCase\:\:never\(\)\.$#'
-			identifier: staticMethod.dynamicCall
-			count: 1
-			path: tests/framework/console/controllers/ServeControllerTest.php
-
-		-
-			message: '#^Dynamic call to static method PHPUnit\\Framework\\TestCase\:\:once\(\)\.$#'
-			identifier: staticMethod.dynamicCall
-			count: 3
 			path: tests/framework/console/controllers/ServeControllerTest.php
 
 		-

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <phpunit
   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd"
+  xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/11.5/phpunit.xsd"
   backupGlobals="true"
   bootstrap="./tests/bootstrap.php"
   cacheDirectory=".phpunit.cache"

--- a/tests/framework/widgets/ActiveFieldTest.php
+++ b/tests/framework/widgets/ActiveFieldTest.php
@@ -10,7 +10,6 @@ declare(strict_types=1);
 
 namespace yiiunit\framework\widgets;
 
-use DMS\PHPUnitExtensions\ArraySubset\ArraySubsetAsserts;
 use Exception;
 use PHPUnit\Framework\Attributes\DataProviderExternal;
 use PHPUnit\Framework\Attributes\Depends;
@@ -36,8 +35,6 @@ use function sprintf;
  */
 class ActiveFieldTest extends TestCase
 {
-    use ArraySubsetAsserts;
-
     /**
      * @var ActiveFieldExtend
      */
@@ -638,22 +635,32 @@ EOD;
         $this->activeField->textInput();
         $actualValue = $this->activeField->getClientOptions();
 
-        $this->assertArraySubset([
+        $expected = [
             'id' => 'custom-input-id',
             'name' => $this->attributeName,
             'container' => '.field-custom-input-id',
             'input' => '#custom-input-id',
-        ], $actualValue);
+        ];
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $actualValue);
+            $this->assertSame($value, $actualValue[$key]);
+        }
 
         $this->activeField->textInput(['id' => 'custom-textinput-id']);
         $actualValue = $this->activeField->getClientOptions();
 
-        $this->assertArraySubset([
+        $expected = [
             'id' => 'custom-textinput-id',
             'name' => $this->attributeName,
             'container' => '.field-custom-textinput-id',
             'input' => '#custom-textinput-id',
-        ], $actualValue);
+        ];
+
+        foreach ($expected as $key => $value) {
+            $this->assertArrayHasKey($key, $actualValue);
+            $this->assertSame($value, $actualValue[$key]);
+        }
     }
 
     public function testAriaAttributes(): void


### PR DESCRIPTION
# Pull Request

| Q            | A                                                                  |
| ------------ | ------------------------------------------------------------------ |
| Is bugfix?   | ✔️                                                              |
| New feature? | ❌                                                              |
| Breaks BC?   | ❌                                                              |
